### PR TITLE
[DEV] Automate CHANGELOG.md creation using git-chglog

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,56 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,15 +1,9 @@
-{{ if .Versions -}}
-<a name="unreleased"></a>
-## [Unreleased]
+# Changelog
+All notable changes to this project will be documented in this file.  
+This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-{{ if .Unreleased.CommitGroups -}}
-{{ range .Unreleased.CommitGroups -}}
-### {{ .Title }}
-{{ range .Commits -}}
-- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
-{{ end }}
-{{ end -}}
-{{ end -}}
+{{ if .Versions -}}
+A list of unreleased changes can be found [here]({{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD).
 {{ end -}}
 
 {{ range .Versions }}
@@ -18,7 +12,7 @@
 {{ range .CommitGroups -}}
 ### {{ .Title }}
 {{ range .Commits -}}
-- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }} [`{{ .Hash.Short }}`]({{ $.Info.RepositoryURL }}/commit/{{ .Hash.Long }})
 {{ end }}
 {{ end -}}
 
@@ -26,13 +20,6 @@
 ### Reverts
 {{ range .RevertCommits -}}
 - {{ .Revert.Header }}
-{{ end }}
-{{ end -}}
-
-{{- if .MergeCommits -}}
-### Pull Requests
-{{ range .MergeCommits -}}
-- {{ .Header }}
 {{ end }}
 {{ end -}}
 
@@ -47,7 +34,6 @@
 {{ end -}}
 
 {{- if .Versions }}
-[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
 {{ range .Versions -}}
 {{ if .Tag.Previous -}}
 [{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}

--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,14 +1,17 @@
 # Changelog
-All notable changes to this project will be documented in this file.  
-This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 {{ if .Versions -}}
 A list of unreleased changes can be found [here]({{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD).
 {{ end -}}
 
 {{ range .Versions }}
-<a name="{{ .Tag.Name }}"></a>
-## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{- if not (eq .Tag.Name "v0.1.0" "v0.2.0" "v0.3.0" "v0.3.1" "v0.4.0" "v0.5.0" "v0.6.0" "v0.7.0" "v0.7.1" "v0.8.0" "v0.8.1" "v0.9.0") }}
+<a name="{{ trimPrefix "v" .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ trimPrefix "v" .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
 {{ range .CommitGroups -}}
 ### {{ .Title }}
 {{ range .Commits -}}
@@ -32,11 +35,131 @@ A list of unreleased changes can be found [here]({{ .Info.RepositoryURL }}/compa
 {{ end -}}
 {{ end -}}
 {{ end -}}
+{{ end -}}
 
-{{- if .Versions }}
+
+## [0.9.0] - 2021-10-19
+### Added
+- have more different tag-wahoo-xml files and move them to folders. Modify tag-wahoo.xml to differently display some "place"-tags [PR34](https://github.com/treee111/wahooMapsCreator/issues/34)
+- tag-wahoo-v12.xml which is a updated version of the current tag-wahoo-hidrive2.xml. Bus_guideways have been removed and the zoom-appear levels are copied from the original wahoo maps. This really should replace tag-wahoo.xml eventually when v12 maps are created. [PR38](https://github.com/treee111/wahooMapsCreator/pull/38)
+- Howto doc for manually adding routing tiles [PR32](https://github.com/treee111/wahooMapsCreator/pull/32)
+### Changed
+- move "central" download functions from downloader to file_directory_functions
+- move files from common_resources into two new folders: common_download & common_python and into tooling [PR33](https://github.com/treee111/wahooMapsCreator/pull/33)
+- format python files in directory common_python using "autopep8" [PR35](https://github.com/treee111/wahooMapsCreator/pull/35) [PR37](https://github.com/treee111/wahooMapsCreator/pull/37)
+- Replaced the publicly available osmconvert.exe (https://wiki.openstreetmap.org/wiki/Osmconvert) 0.8.8 with a special newer version 0.8.10. This version does NOT include the zlib library which enables processing of .osm.pbf files larger then 4GB on windows. The old version did have zlib which prevented processing of > 4Gb .osm.pbf files on windows. [PR38](https://github.com/treee111/wahooMapsCreator/pull/38)
+### Fixed
+- fix bug in download handling of land polygons file which was introduced with [PR33](https://github.com/treee111/wahooMapsCreator/pull/33). [PR35](https://github.com/treee111/wahooMapsCreator/pull/35)
+
+## [0.8.1] - 2021-09-10
+### Fixed
+- change dynamic access to constants-values to prevent console-errors [#29](https://github.com/treee111/wahooMapsCreator/issues/29) [PR30](https://github.com/treee111/wahooMapsCreator/issues/30)
+
+## [0.8.0] - 2021-08-11
+### Added
+- download a geofabrik file only once if more countries are in the same geofabrik-country [#11](https://github.com/treee111/wahooMapsCreator/issues/11) [PR28](https://github.com/treee111/wahooMapsCreator/issues/28)
+### Fixed
+- `-h` and `--help` works again
+
+## [0.7.1] - 2021-07-26
+### Fixed
+- Release .zip file without doubled subfolder. Directly zip content
+
+## [0.7.0] - 2021-07-25
+### Added
+- GUI functionality with all relevant settings (equals CLI arguments) [#21](https://github.com/treee111/wahooMapsCreator/issues/21) [PR24](https://github.com/treee111/wahooMapsCreator/issues/24)
+  - start gui via `python3 wahoo_map_creator.py` or `python wahoo_map_creator.py`
+- Release .zip file will only contain relevant files for execution [PR25](https://github.com/treee111/wahooMapsCreator/issues/25)
+### Fixed
+- When running without calculation of border countries, ignore border countries in all steps [PR24](https://github.com/treee111/wahooMapsCreator/issues/24)
+### Changed
+- move contents into the correct directory [PR23](https://github.com/treee111/wahooMapsCreator/issues/23)
+### Removed
+- doubled / not needed files and folders [PR23](https://github.com/treee111/wahooMapsCreator/issues/23)
+
+## [0.6.0] - 2021-07-10
+### Added
+- CLI arguments for relevant settings. No more editing of python files needed [#15](https://github.com/treee111/wahooMapsCreator/issues/15) [PR19](https://github.com/treee111/wahooMapsCreator/issues/19)
+  - see `python3 wahoo_map_creator.py -h` or `python wahoo_map_creator.py -h` for possible arguments
+### Changed
+- pylint findings corrected
+### Removed
+- settings for processing should no longer be made in the file wahoo_map_creator.py. --> Use CLI arguments
+### Fixed
+- unittests run also on windows (paths are now OS-independent)
+
+## [0.5.0] - 2021-07-04
+### Added
+- Parameter to control download and processing of border countries or not [PR18](https://github.com/treee111/wahooMapsCreator/issues/18)
+- unittests for downloader.py and osm_maps_functions.py files [PR16](https://github.com/treee111/wahooMapsCreator/issues/16)
+### Changed
+- pylint findings corrected
+- a lot of refactored (focus methods, constructors)
+- refactor downloader-methods for testing with unittests
+- correctly check force_download and force_processing against boolean
+- fix pylint findings (focus documentation and imports)
+- reduce (double) imported standard modules & delete unused imports
+- move call of empty directories-creation
+
+## [0.4.0] - 2021-07-01
+### Added
+- parameter force_download to differentiate between forcing download of new maps and force of processing maps
+- enable selective download of .osm.pdf files. Only download out-of-date files
+
+### Changed
+- correct pylint findings
+- unify macOS and Windows python file into one
+  - the new file is: wahoo_mapcreator.py in root folder
+  - deletion of tooling_mac/mac_wahoo_map_creator.py
+- a lot of refactoring: move coding to class FileDir and Downloader
+
+### Deprecated
+- the tooling_mac/ and tooling_windows python files will be removed in the future
+
+## [0.3.1] - 2021-06-17
+### Added
+- configuration for virtual python environment (venv)
+### Changed
+- correct import path for custom python package
+### Removed
+- unused official and custom python packages
+
+## [0.3.0] - 2021-06-16
+### Added
+- README, Quick Start Guides & documentation written
+- Refactoring & Renaming of .py files
+
+## [0.2.0] - 2021-06-10
+### Added
+- bat file with GUI for Windows (with corresponding python file)
+- automatic creation of Releases when pushing a tag with semantic version (eg. v.1.1)
+- `docs` directory
+### Changed
+- deleted one directory level in `tooling_windows`
+- move leftover common-files to `common_resources` directory
+- README with picture and changed text
+### Removed
+- existing "single-file" program files & bat callers, mainly:
+  - macOS/Unix: `tooling_mac/wahoo-map-creator-osmium-working.py`
+  - Windows:    `tooling_windows/Windows-Wahoo-Map-Creator-Osmosis/wahoo-map-creator-osmosis.py`
+- doubled files
+
+## [0.1.0] - 2021-06-08
+### Added
+- created two files which use mainly the coding from `common_resources`:
+  - macOS/Unix: `tooling_mac/wahoo-map-creator-osmium-using-common.py`
+  - Windows:    `tooling_windows/Windows-Wahoo-Map-Creator-Osmosis/wahoo-map-creator-osmosis-using-common.py`
+- `common_resources`: directory for common coding & resources #8
+  - with folders for resources and files generally needed 
+  - with extracted common coding from these two files
+    - macOS/Unix: `tooling_mac/wahoo-map-creator-osmium-working.py`
+    - Windows:    `tooling_windows/Windows-Wahoo-Map-Creator-Osmosis/wahoo-map-creator-osmosis.py`
+
+{{ if .Versions }}
 {{ range .Versions -}}
 {{ if .Tag.Previous -}}
 [{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
 {{ end -}}
 {{ end -}}
 {{ end -}}
+[0.1.0]: https://github.com/treee111/wahooMapsCreator/releases/tag/v0.1.0

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -5,23 +5,27 @@ info:
   repository_url: https://github.com/treee111/wahooMapsCreator
 options:
   commits:
-    # filters:
-    #   Type:
-    #     - feat
-    #     - fix
-    #     - perf
-    #     - refactor
+    filters:
+      Type:
+        - FEATURE
+        - FIX
+        - PERF
+        - BREAKING
   commit_groups:
-    # title_maps:
-    #   feat: Features
-    #   fix: Bug Fixes
-    #   perf: Performance Improvements
-    #   refactor: Code Refactoring
+    title_maps:
+      FEATURE: Features
+      FIX: Bug Fixes
+      PERF: Performance Improvements
+      BREAKING: Breaking Changes
   header:
-    pattern: "^(\\w*)\\:\\s(.*)$"
+    pattern: "^\\[(\\w*)\\]\\s(?:([^\\:]*)\\:\\s)?(.*)$"
     pattern_maps:
       - Type
+      - Scope
       - Subject
+  issues:
+    prefix:
+      - "#"
   notes:
     keywords:
       - BREAKING CHANGE

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -4,20 +4,20 @@ info:
   title: CHANGELOG
   repository_url: https://github.com/treee111/wahooMapsCreator
 options:
-  tag_filter_pattern: '^v'
+  tag_filter_pattern: "^v"
   sort: "semver"
   commits:
     filters:
       Type:
         - FEATURE
         - FIX
-        - PERF
+        - DEV
         - BREAKING
   commit_groups:
     title_maps:
       FEATURE: Features
       FIX: Bug Fixes
-      PERF: Performance Improvements
+      DEV: Development/Infrastructure/Test/CI
       BREAKING: Breaking Changes
   header:
     pattern: "^\\[(\\w*)\\]\\s(?:([^\\:]*)\\:\\s)?(.*)$"

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,27 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/treee111/wahooMapsCreator
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -4,6 +4,8 @@ info:
   title: CHANGELOG
   repository_url: https://github.com/treee111/wahooMapsCreator
 options:
+  tag_filter_pattern: '^v'
+  sort: "semver"
   commits:
     filters:
       Type:

--- a/.github/workflows/git-release-pre.yml
+++ b/.github/workflows/git-release-pre.yml
@@ -1,9 +1,9 @@
-name: Git Release
+name: Git Pre-Release
 
 on:
   push:
     tags:
-    - v[0-9]+.[0-9]+.[0-9]+
+    - v[0-9]+.[0-9]+.[0-9]+-pre**
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -24,7 +24,8 @@ jobs:
         uses: docker://antonyurchenko/git-release:latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NAME_PREFIX: "Release "
+          RELEASE_NAME_PREFIX: "Pre-Release "
+          PRE_RELEASE: true
         with:
           args: |
             dist/wahooMapsCreator-*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Types of changes
-
-- `Added` for new features.
-- `Changed` for changes in existing functionality.
-- `Deprecated` for soon-to-be removed features.
-- `Removed` for now removed features.
-- `Fixed` for any bug fixes.
-- `Security` in case of vulnerabilities.
-
-## [Unreleased]
+A list of unreleased changes can be found [here](https://github.com/treee111/wahooMapsCreator/compare/v0.9.0...HEAD).
 ## [0.9.0] - 2021-10-19
 ### Added
 - have more different tag-wahoo-xml files and move them to folders. Modify tag-wahoo.xml to differently display some "place"-tags [PR34](https://github.com/treee111/wahooMapsCreator/issues/34)
@@ -132,16 +123,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Windows:    `tooling_windows/Windows-Wahoo-Map-Creator-Osmosis/wahoo-map-creator-osmosis.py`
 
 
-[unreleased]: https://github.com/treee111/wahooMapsCreator/compare/v0.9.0...HEAD
-[0.9.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.8.1...v0.9.0
-[0.8.1]: https://github.com/treee111/wahooMapsCreator/compare/v0.8.0...v0.8.1
-[0.8.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.7.1...v0.8.0
-[0.7.1]: https://github.com/treee111/wahooMapsCreator/compare/v0.7.0...v0.7.1
-[0.7.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.3.1...v0.4.0
-[0.3.1]: https://github.com/treee111/wahooMapsCreator/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.1.0...v0.2.0
+[v0.9.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.8.1...v0.9.0
+[v0.8.1]: https://github.com/treee111/wahooMapsCreator/compare/v0.8.0...v0.8.1
+[v0.8.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.7.1...v0.8.0
+[v0.7.1]: https://github.com/treee111/wahooMapsCreator/compare/v0.7.0...v0.7.1
+[v0.7.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.6.0...v0.7.0
+[v0.6.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.5.0...v0.6.0
+[v0.5.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.4.0...v0.5.0
+[v0.4.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.3.1...v0.4.0
+[v0.3.1]: https://github.com/treee111/wahooMapsCreator/compare/v0.3.0...v0.3.1
+[v0.3.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/treee111/wahooMapsCreator/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/treee111/wahooMapsCreator/releases/tag/v0.1.0


### PR DESCRIPTION
## This PR…

- introduces [git-chglog](https://github.com/git-chglog/git-chglog) to automatically create the entries in the CHANGELOG.md file based on the merge-commits of the squashed pull requests.
- introduces a Pre-Release[git-release](https://github.com/anton-yurchenko/git-release) github-actions workflow

closes #36

## Todo

- [x] check, how the github-action git-release behaves in combination with this change and how the CHANGELOG.md and release-CHANGELOG can be of the same style
  - had to remove the leading "v" from the tag in the ##-headlines: [v0.10.0-pre3] becomes [0.10.0-pre3]
  - needed changes are also in this PR
  - the Release is created like before, just with other groups. Thats because the groups changed from manual to automatic CHANGELOG.md creation. 

## Considerations and implementations

For a commit to appear in the CHANGELOG.md, it has to follow a certain naming pattern:
`[type] ...(#PR-number)`

possible types:
- FEATURE
- FIX
- PERF
- BREAKING

example: `[FEATURE] Add check for required input parameter for CLI and GUI (#41)`

After installing git-chglog locally, the CHANGELOG.md can be generated with this command:
`git-chglog -o CHANGELOG.md`
To generate the CHANGELOG for a upcoming release (no tag exists yet), the following command can be used:
`git-chglog -o CHANGELOG.md --next-tag v0.10.0`

The already existing CHANGELOG entries were copied to the template so that they get included in the generated CHANGELOG.md even if the commits are not following the naming pattern.

## How to test

see upper chapter

## Optional
### Unit-Test(s) added

Having this section helps reminds developers to always add tests, or explain themselves if they can’t!

### Screenshots

Having this section makes visual changes immediately obvious, and means visual bugs can often be identified instantly. Also, the screenshots are useful for non-devs preparing content for sprint review, or signing off work.

It’s worth mentioning that in less visual projects, this section could be called “Changes” and contain logs / process flows / etc. This section sometimes contains screenshots of Charles network requests or LogCat messages as well as normal screenshots.