### PR TITLE
[FEATURE] Change creation of tiles.zip and maps.zip to support very large countries

### DIFF
--- a/common_python/input.py
+++ b/common_python/input.py
@@ -33,6 +33,9 @@ class InputData():
         self.only_merge = False
 
         self.tag_wahoo_xml = "tag-wahoo.xml"
+        # Keep (True) or delete (False) the /output/country/
+        # and /output/country-maps map folders after compression
+        self.keep_map_folders = False
 
 
 class Input(tk.Tk):
@@ -140,6 +143,9 @@ class Input(tk.Tk):
         # specify the file with tags to keep in the output // file needs to be in common_resources
         parser.add_argument('-om', '--only_merge', action='store_true',
                             help="only merge, do no other processing")
+        # option to keep the /output/country/ and /output/country-maps folders in the output
+        parser.add_argument('-km', '--keep_map_folders', action='store_true',
+                            help="keep the country and country-maps folders in the output")
 
         # set instance-attributes of class
         # try:
@@ -155,6 +161,7 @@ class Input(tk.Tk):
         o_input_data.save_cruiser = args.cruiser
         o_input_data.tag_wahoo_xml = args.tag_wahoo_xml
         o_input_data.only_merge = args.only_merge
+        self.o_input_data.keep_map_folders = args.keep_map_folders
 
         return o_input_data
 

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import sys
 import platform
+import shutil
 
 # import custom python packages
 from common_python import file_directory_functions as fd_fct
@@ -516,15 +517,56 @@ class OsmMaps:
         print('\n# Zip .map.lzma files')
         print(f'+ Country: {self.country_name}')
 
+# Check for us/utah etc names
+        try:
+            res = self.country_name.index('/')
+            self.country_name = self.country_name[res+1:]
+        except:
+            pass
+
+        # copy the needed tiles to the country folder
+        print(f'Copying Wahoo tiles to output folders')
+        for tile in self.tiles:
+            src = os.path.join(f'{fd_fct.OUTPUT_DIR}',
+                               f'{tile["x"]}', f'{tile["y"]}.map.lzma')
+            dst = os.path.join(
+                f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}', f'{tile["x"]}', f'{tile["y"]}.map.lzma')
+            outdir = os.path.join(
+                f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}', f'{tile["x"]}')
+            if not os.path.isdir(outdir):
+                os.makedirs(outdir)
+            try:
+                shutil.copy2(src, dst)
+            except:
+                print(f'Error copying tiles of country {self.country_name}')
+                sys.exit()
+
+            src = os.path.join(f'{fd_fct.OUTPUT_DIR}',
+                               f'{tile["x"]}', f'{tile["y"]}.map.lzma.12')
+            dst = os.path.join(f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}',
+                               f'{tile["x"]}', f'{tile["y"]}.map.lzma.12')
+            outdir = os.path.join(
+                f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}', f'{tile["x"]}')
+            if not os.path.isdir(outdir):
+                os.makedirs(outdir)
+            try:
+                shutil.copy2(src, dst)
+            except:
+                print(
+                    f'Error copying precense files of country {self.country_name}')
+                sys.exit()
+
         # Make Wahoo zip file
         # Windows
         if platform.system() == "Windows":
             path_7za = os.path.join(fd_fct.TOOLING_WIN_DIR, '7za')
-            cmd = [path_7za, 'a', '-tzip', '-m0=lzma', '-mx9',
-                   '-mfb=273', '-md=1536m', self.country_name + '.zip']
+            cmd = [path_7za, 'a', '-tzip', self.country_name,
+                   os.path.join(f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}', '*')]
+
         # Non-Windows
         else:
-            cmd = ['zip', '-r', self.country_name + '.zip']
+            cmd = ['zip', '-r', self.country_name + '.zip',
+                   os.path.join(f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}', '*')]
 
         for tile in self.tiles:
             cmd.append(os.path.join(f'{tile["x"]}', f'{tile["y"]}.map.lzma'))
@@ -539,14 +581,40 @@ class OsmMaps:
         Make Cruiser map files zip file
         """
 
+        # Check for us/utah etc names
+        try:
+            res = self.country_name.index('/')
+            self.country_name = self.country_name[res+1:]
+        except:
+            pass
+
+        # copy the needed tiles to the country folder
+        print(f'Copying map tiles to output folders')
+        for tile in self.tiles:
+            src = os.path.join(f'{fd_fct.OUTPUT_DIR}',
+                               f'{tile["x"]}', f'{tile["y"]}.map')
+            dst = os.path.join(
+                f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}-maps', f'{tile["x"]}', f'{tile["y"]}.map')
+            outdir = os.path.join(
+                f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}-maps', f'{tile["x"]}')
+            if not os.path.isdir(outdir):
+                os.makedirs(outdir)
+            try:
+                shutil.copy2(src, dst)
+            except:
+                print(f'Error copying maps of country {self.country_name}')
+                sys.exit()
+
         # Make Cruiser map files zip file
         # Windows
         if platform.system() == "Windows":
-            cmd = [os.path.join(fd_fct.TOOLING_WIN_DIR, '7za'), 'a',
-                   '-tzip', '-m0=lzma', self.country_name + '-maps.zip']
+            cmd = [os.path.join(fd_fct.TOOLING_WIN_DIR, '7za'), 'a', '-tzip', self.country_name +
+                   '-maps.zip', os.path.join(f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}-maps', '*')]
+
         # Non-Windows
         else:
-            cmd = ['zip', '-r', self.country_name + '-maps.zip']
+            cmd = ['zip', '-r', self.country_name + '-maps.zip',
+                   os.path.join(f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}-maps', '*')]
 
         for tile in self.tiles:
             cmd.append(os.path.join(f'{tile["x"]}', f'{tile["y"]}.map'))

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -104,7 +104,6 @@ class OsmMaps:
         # Windows
         if platform.system() == "Windows":
             for key, val in self.border_countries.items():
-
                 out_file = os.path.join(fd_fct.OUTPUT_DIR,
                                         f'filtered-{key}.osm.pbf')
                 out_file_o5m = os.path.join(fd_fct.OUTPUT_DIR,
@@ -163,7 +162,6 @@ class OsmMaps:
         # Non-Windows
         else:
             for key, val in self.border_countries.items():
-
                 out_file_o5m_filtered = os.path.join(fd_fct.OUTPUT_DIR,
                                                      f'filtered-{key}.o5m.pbf')
                 out_file_o5m_filtered_names = os.path.join(fd_fct.OUTPUT_DIR,

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -104,7 +104,9 @@ class OsmMaps:
         # Windows
         if platform.system() == "Windows":
             for key, val in self.border_countries.items():
-                # print(key, val)
+
+                out_file = os.path.join(fd_fct.OUTPUT_DIR,
+                                        f'filtered-{key}.osm.pbf')
                 out_file_o5m = os.path.join(fd_fct.OUTPUT_DIR,
                                             f'outFile-{key}.o5m')
                 out_file_o5m_filtered = os.path.join(fd_fct.OUTPUT_DIR,
@@ -161,6 +163,7 @@ class OsmMaps:
         # Non-Windows
         else:
             for key, val in self.border_countries.items():
+
                 out_file_o5m_filtered = os.path.join(fd_fct.OUTPUT_DIR,
                                                      f'filtered-{key}.o5m.pbf')
                 out_file_o5m_filtered_names = os.path.join(fd_fct.OUTPUT_DIR,
@@ -219,7 +222,7 @@ class OsmMaps:
                             f'{tile["top"]+0.1:.6f}'])
                 cmd.append(land_file)
                 cmd.append(fd_fct.LAND_POLYGONS_PATH)
-                # print(cmd)
+
                 subprocess.run(cmd, check=True)
 
             if not os.path.isfile(out_file+'1.osm') or self.force_processing is True:
@@ -231,7 +234,7 @@ class OsmMaps:
                 else:
                     cmd = ['python3', os.path.join(fd_fct.TOOLING_DIR,
                                                    'shape2osm.py'), '-l', out_file, land_file]
-                # print(cmd)
+
                 subprocess.run(cmd, check=True)
             tile_count += 1
 
@@ -302,7 +305,6 @@ class OsmMaps:
                         cmd.append(val['filtered_file'])
                         cmd.append('-o='+out_file)
 
-                        # print(cmd)
                         result = subprocess.run(cmd, check=True)
                         if result.returncode != 0:
                             print(f'Error in Osmosis with country: {country}')
@@ -317,7 +319,6 @@ class OsmMaps:
                         cmd.append(val['filtered_file_names'])
                         cmd.append('-o='+out_file_names)
 
-                        # print(cmd)
                         result = subprocess.run(cmd, check=True)
                         if result.returncode != 0:
                             print(f'Error in Osmosis with country: {country}')
@@ -333,7 +334,6 @@ class OsmMaps:
                         cmd.extend(['-o', out_file])
                         cmd.extend(['--overwrite'])
 
-                        # print(cmd)
                         result = subprocess.run(cmd, check=True)
                         if result.returncode != 0:
                             print(f'Error in Osmium with country: {country}')
@@ -517,15 +517,15 @@ class OsmMaps:
         print('\n# Zip .map.lzma files')
         print(f'+ Country: {self.country_name}')
 
-# Check for us/utah etc names
+        # Check for us/utah etc names
         try:
             res = self.country_name.index('/')
             self.country_name = self.country_name[res+1:]
-        except:
+        except ValueError:
             pass
 
         # copy the needed tiles to the country folder
-        print(f'Copying Wahoo tiles to output folders')
+        print('Copying Wahoo tiles to output folders')
         for tile in self.tiles:
             src = os.path.join(f'{fd_fct.OUTPUT_DIR}',
                                f'{tile["x"]}', f'{tile["y"]}.map.lzma')
@@ -541,12 +541,8 @@ class OsmMaps:
                 print(f'Error copying tiles of country {self.country_name}')
                 sys.exit()
 
-            src = os.path.join(f'{fd_fct.OUTPUT_DIR}',
-                               f'{tile["x"]}', f'{tile["y"]}.map.lzma.12')
-            dst = os.path.join(f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}',
-                               f'{tile["x"]}', f'{tile["y"]}.map.lzma.12')
-            outdir = os.path.join(
-                f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}', f'{tile["x"]}')
+            src = src + '.12'
+            dst = dst + '.12'
             if not os.path.isdir(outdir):
                 os.makedirs(outdir)
             try:
@@ -595,11 +591,11 @@ class OsmMaps:
         try:
             res = self.country_name.index('/')
             self.country_name = self.country_name[res+1:]
-        except:
+        except ValueError:
             pass
 
         # copy the needed tiles to the country folder
-        print(f'Copying map tiles to output folders')
+        print('Copying map tiles to output folders')
         for tile in self.tiles:
             src = os.path.join(f'{fd_fct.OUTPUT_DIR}',
                                f'{tile["x"]}', f'{tile["y"]}.map')

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -509,7 +509,7 @@ class OsmMaps:
         # logging
         print('# Creating .map files: OK')
 
-    def zip_map_files(self):
+    def zip_map_files(self, keep_map_folders):
         """
         Zip .map.lzma files
         """
@@ -573,10 +573,20 @@ class OsmMaps:
 
         subprocess.run(cmd, cwd=fd_fct.OUTPUT_DIR, check=True)
 
+        # Keep (True) or delete (False) the country/region map folders after compression
+        if keep_map_folders is False:
+            try:
+                shutil.rmtree(os.path.join(
+                    f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}'))
+            except OSError:
+                print(
+                    f'Error, could not delete folder \
+                        {os.path.join(fd_fct.OUTPUT_DIR, self.country_name)}')
+
         # logging
         print('# Zip .map.lzma files: OK \n')
 
-    def make_cruiser_files(self):
+    def make_cruiser_files(self, keep_map_folders):
         """
         Make Cruiser map files zip file
         """
@@ -620,3 +630,13 @@ class OsmMaps:
             cmd.append(os.path.join(f'{tile["x"]}', f'{tile["y"]}.map'))
 
         subprocess.run(cmd, cwd=fd_fct.OUTPUT_DIR, check=True)
+
+        # Keep (True) or delete (False) the country/region map folders after compression
+        if keep_map_folders is False:
+            try:
+                shutil.rmtree(os.path.join(
+                    f'{fd_fct.OUTPUT_DIR}', f'{self.country_name}-maps'))
+            except OSError:
+                print(
+                    f'Error, could not delete folder \
+                        {os.path.join(fd_fct.OUTPUT_DIR, self.country_name)}-maps')

--- a/wahoo_map_creator.py
+++ b/wahoo_map_creator.py
@@ -60,8 +60,8 @@ oOSMmaps.merge_splitted_tiles_with_land_and_sea(oInputData.border_countries)
 oOSMmaps.create_map_files(oInputData.save_cruiser, oInputData.tag_wahoo_xml)
 
 # Zip .map.lzma files
-oOSMmaps.zip_map_files()
+oOSMmaps.zip_map_files(oInputData.keep_map_folders)
 
 # Make Cruiser map files zip file
 if oInputData.save_cruiser is True:
-    oOSMmaps.make_cruiser_files()
+    oOSMmaps.make_cruiser_files(oInputData.keep_map_folders)


### PR DESCRIPTION
# This PR…
extracted from #40:
- Changes how the resulting tiles.zip and maps.zip file is made. Now files are copied from the 'tilestore' to a country-name and country-name-maps folder. This folder is then passed to the compressor instead of building an enormous command line with all file names specified. This would, for large countries like Russia, result in errors because the command line was to long.
- Added advantage: Optionally you can choose via CLI to keep these folders so you can instantly copy the files to your device or check them in Cruiser.
- Copies the - currently static numbered - tile-present/version files (created in #46) to the tiles.zip archive