### PR TITLE
[FIX] storing and interpretation of CLI arguments

### DIFF
--- a/common_python/input.py
+++ b/common_python/input.py
@@ -152,7 +152,8 @@ class Input(tk.Tk):
         o_input_data.force_download = args.forcedownload
         o_input_data.force_processing = args.forceprocessing
         o_input_data.border_countries = args.bordercountries
-        o_input_data.save_cruiser = args.tag_wahoo_xml
+        o_input_data.save_cruiser = args.cruiser
+        o_input_data.tag_wahoo_xml = args.tag_wahoo_xml
         o_input_data.only_merge = args.only_merge
 
         return o_input_data


### PR DESCRIPTION
# “This PR…”
stores these two CLI arguments so that they can be correctly accessed later: 
- save_cruiser has incorrect value
- tag_wahoo_xml was not considered at all

# “Considerations and implementations”

The correction is only valid for CLI processind. Using the GUI, everything is still fine.
Before the change, these condition was never true, because `save_cruiser` always had the value of the tax_wahoo.xml
https://github.com/treee111/wahooMapsCreator/blob/bbdedd176bc119b143a55f639641367e1275533f/wahoo_map_creator.py#L62-L64

# “How to test”

Having an ordered, straightforward list of steps to test the changes massively helps overall understanding. This list can also be used as hints for QA, and is a good place to upload any custom configuration files etc needed.

# Optional
## “Unit-Test(s) added”

Having this section helps reminds developers to always add tests, or explain themselves if they can’t!

## “Screenshots”

Having this section makes visual changes immediately obvious, and means visual bugs can often be identified instantly. Also, the screenshots are useful for non-devs preparing content for sprint review, or signing off work.

It’s worth mentioning that in less visual projects, this section could be called “Changes” and contain logs / process flows / etc. This section sometimes contains screenshots of Charles network requests or LogCat messages as well as normal screenshots.