### PR TITLE
[FIX] copy tile-present/version files to map archive

### DIFF
--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -464,7 +464,11 @@ class OsmMaps:
             cmd = ['zip', '-r', self.country_name + '.zip']
 
         for tile in self.tiles:
-            cmd.append(os.path.join(f'{tile["x"]}', f'{tile["y"]}.map.lzma'))
+            cmd.append(os.path.join(
+                f'{tile["x"]}', f'{tile["y"]}.map.lzma'))
+            cmd.append(os.path.join(
+                f'{tile["x"]}', f'{tile["y"]}.map.lzma.12'))
+
         # print(cmd)
         subprocess.run(cmd, cwd=fd_fct.OUTPUT_DIR, check=True)
 


### PR DESCRIPTION
## This PR…

adds the - currently static numbered - tile-present/version files to the map archival commands.
