### PR TITLE
[DEV] Define sort-sequence of CHANGELOG entries

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -7,6 +7,7 @@ options:
   tag_filter_pattern: "^v"
   sort: "semver"
   commits:
+    sort_by: "Author.Date"
     filters:
       Type:
         - FEATURE
@@ -14,6 +15,12 @@ options:
         - DEV
         - BREAKING
   commit_groups:
+    sort_by: Custom
+    title_order:
+      - BREAKING
+      - FEATURE
+      - FIX
+      - DEV
     title_maps:
       FEATURE: Features
       FIX: Bug Fixes


### PR DESCRIPTION
**Thank you for your contribution!** 🙌

To get it merged faster, please use this template and replace as many "{...}" as possible and kindly review the checklist below.

## This PR…

defines the sort-sequence of CHANGELOG entries, namely:
- commit-groups
- commits in a commit-group

adjusts https://github.com/treee111/wahooMapsCreator/pull/45
closes https://github.com/treee111/wahooMapsCreator/issues/53

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] commits (and commit-messages) are understandable