### PR TITLE
[FIX] Process GUI / tk coding only if running in GUI mode

### DIFF
--- a/common_python/input.py
+++ b/common_python/input.py
@@ -50,37 +50,37 @@ class Input(tk.Tk):
     """
 
     def __init__(self, *args, **kwargs):
-        if len(sys.argv) == 1:
-            self.gui_mode = True
-        else:
-            self.gui_mode = False
-
         self.o_input_data = InputData()
 
         if 'microsoft' in uname().release:
             self.gui_mode = False
             return
 
-        tk.Tk.__init__(self, *args, **kwargs)
+        if len(sys.argv) == 1:
+            self.gui_mode = True
 
-        # self.geometry("420x360")
-        self.title("Wahoo map creator")
-        self.configure(bg="white")
-        self.option_add("*Font", "Calibri 16")
+            tk.Tk.__init__(self, *args, **kwargs)
 
-        container = tk.Frame(self)
-        container.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+            # self.geometry("420x360")
+            self.title("Wahoo map creator")
+            self.configure(bg="white")
+            self.option_add("*Font", "Calibri 16")
 
-        self.first = ComboboxesEntryField(
-            container, self.o_input_data.max_days_old)
-        self.first.pack(side=tk.TOP, fill=tk.X)
+            container = tk.Frame(self)
+            container.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
 
-        self.third = Checkbuttons(
-            container, self.o_input_data, controller=self)
-        self.third.pack(side=tk.TOP, fill=tk.X)
+            self.first = ComboboxesEntryField(
+                container, self.o_input_data.max_days_old)
+            self.first.pack(side=tk.TOP, fill=tk.X)
 
-        self.four = Buttons(container, controller=self)
-        self.four.pack(side=tk.TOP, fill=tk.X)
+            self.third = Checkbuttons(
+                container, self.o_input_data, controller=self)
+            self.third.pack(side=tk.TOP, fill=tk.X)
+
+            self.four = Buttons(container, controller=self)
+            self.four.pack(side=tk.TOP, fill=tk.X)
+        else:
+            self.gui_mode = False
 
     def start_gui(self):
         """

--- a/common_python/input.py
+++ b/common_python/input.py
@@ -50,8 +50,6 @@ class Input(tk.Tk):
     """
 
     def __init__(self, *args, **kwargs):
-        self.o_input_data = InputData()
-
         if 'microsoft' in uname().release:
             self.gui_mode = False
             return
@@ -62,6 +60,8 @@ class Input(tk.Tk):
             tk.Tk.__init__(self, *args, **kwargs)
         else:
             self.gui_mode = False
+
+        self.o_input_data = InputData()
 
     def start_gui(self):
         """

--- a/common_python/input.py
+++ b/common_python/input.py
@@ -60,25 +60,6 @@ class Input(tk.Tk):
             self.gui_mode = True
 
             tk.Tk.__init__(self, *args, **kwargs)
-
-            # self.geometry("420x360")
-            self.title("Wahoo map creator")
-            self.configure(bg="white")
-            self.option_add("*Font", "Calibri 16")
-
-            container = tk.Frame(self)
-            container.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-
-            self.first = ComboboxesEntryField(
-                container, self.o_input_data.max_days_old)
-            self.first.pack(side=tk.TOP, fill=tk.X)
-
-            self.third = Checkbuttons(
-                container, self.o_input_data, controller=self)
-            self.third.pack(side=tk.TOP, fill=tk.X)
-
-            self.four = Buttons(container, controller=self)
-            self.four.pack(side=tk.TOP, fill=tk.X)
         else:
             self.gui_mode = False
 
@@ -86,10 +67,36 @@ class Input(tk.Tk):
         """
         start GUI
         """
+        self.build_gui()
+
         # start GUI
         self.mainloop()
 
         return self.o_input_data
+
+    def build_gui(self):
+        """
+        builds GUI consisting of several parts
+        """
+        # build GUI
+        # self.geometry("420x360")
+        self.title("Wahoo map creator")
+        self.configure(bg="white")
+        self.option_add("*Font", "Calibri 16")
+
+        container = tk.Frame(self)
+        container.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+
+        self.first = ComboboxesEntryField(
+            container, self.o_input_data.max_days_old)
+        self.first.pack(side=tk.TOP, fill=tk.X)
+
+        self.third = Checkbuttons(
+            container, self.o_input_data, controller=self)
+        self.third.pack(side=tk.TOP, fill=tk.X)
+
+        self.four = Buttons(container, controller=self)
+        self.four.pack(side=tk.TOP, fill=tk.X)
 
     def handle_create_map(self, event):
         """


### PR DESCRIPTION
**Thank you for your contribution!** 🙌

To get it merged faster, please use this template and replace as many "{...}" as possible and kindly review the checklist below.

## This PR…

moves tk coding, so that it is not processed during CLI mode.

created from #71

## Considerations and implementations

If tk is not installed and only CLI mode is needed, there occurs an error because the tk coding was processed every time.
Now, the init of the tk objekt is run when GUI mode is asked for and the GUI is build in a separate `build_gui` function called in `start_gui`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] commits (and commit-messages) are understandable
- [ ] {...}
