### PR TITLE
[FIX] Make paths for zip files identical on different OS: macOS and Windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -116,6 +116,23 @@
             ]
         },
         {
+            "name": "malta-only-merge",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceRoot}/wahoo_map_creator.py",
+            "console": "integratedTerminal",
+            "args": [
+                "malta",
+                "-tag",
+                "tag-wahoo.xml",
+                "-fp",
+                "-c",
+                "-md",
+                "100",
+                "-om"
+            ]
+        },
+        {
             "name": "malta-geofabrik",
             "type": "python",
             "request": "launch",

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -598,12 +598,15 @@ class OsmMaps:
             path_7za = os.path.join(fd_fct.TOOLING_WIN_DIR, '7za')
             cmd = [path_7za, 'a', '-tzip']
 
+            cmd.extend(
+                [folder_name + '.zip', os.path.join(".", folder_name, "*")])
+
         # Non-Windows
         else:
             cmd = ['zip', '-r']
 
-        cmd.extend(
-            [folder_name + '.zip', folder_name])
+            cmd.extend(
+                [folder_name + '.zip', folder_name])
         # cmd.append(folder_name + '.zip')
         # cmd.append(os.path.join(fd_fct.OUTPUT_DIR, folder_name))
 

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -603,7 +603,7 @@ class OsmMaps:
             cmd = ['zip', '-r']
 
         cmd.extend(
-            [folder_name + '.zip', os.path.join(fd_fct.OUTPUT_DIR, folder_name)])
+            [folder_name + '.zip', folder_name])
         # cmd.append(folder_name + '.zip')
         # cmd.append(os.path.join(fd_fct.OUTPUT_DIR, folder_name))
 

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -607,8 +607,6 @@ class OsmMaps:
 
             cmd.extend(
                 [folder_name + '.zip', folder_name])
-        # cmd.append(folder_name + '.zip')
-        # cmd.append(os.path.join(fd_fct.OUTPUT_DIR, folder_name))
 
         subprocess.run(cmd, cwd=fd_fct.OUTPUT_DIR, check=True)
 


### PR DESCRIPTION
## This PR…
closes #75 

- the zip created with macOS does not include full path in zip file
- the zip created with Windows does not include country folder in zip file
- with this, the created zips are identical with both OS macOS and Windows

## Considerations and implementations
see #75 for comparison

zip for malta using macOS
![grafik](https://user-images.githubusercontent.com/53038537/149622371-d2907c19-53ad-41dc-bf06-fd04290da0c1.png)

zip for malta using Windows
![image](https://user-images.githubusercontent.com/53038537/149622524-afbfbd57-29aa-4659-82a9-f07505817333.png)

## How to test

1. checkout this branch `git checkout fix-zip-paths-to-be-identical`
2. create any map, e.g. of malta
3. extract the generated zips
4. check folder structure of unzipped folder

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] commits (and commit-messages) are understandable
- [x] {...}
