### PR TITLE
[FEATURE] install: move work-directories `common_download` and `output` to level of wahooMapsCreator to be release independent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,7 @@
 /!.vscode/settings.json
 
 # top level
-/common_download
 /dist
-/output
 /envs
 osmconvert_tempfile.*
 

--- a/common_python/file_directory_functions.py
+++ b/common_python/file_directory_functions.py
@@ -27,9 +27,11 @@ def get_git_root():
 
 # wahooMapsCreator directory
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+PAR_DIR = os.path.abspath(os.path.join(os.path.join(
+    os.path.dirname(__file__), os.pardir), os.pardir))
 COMMON_DIR = os.path.join(ROOT_DIR, 'common_resources')
-COMMON_DL_DIR = os.path.join(ROOT_DIR, 'common_download')
-OUTPUT_DIR = os.path.join(ROOT_DIR, 'output')
+COMMON_DL_DIR = os.path.join(PAR_DIR, 'wahooMapsCreator_download')
+OUTPUT_DIR = os.path.join(PAR_DIR, 'wahooMapsCreator_output')
 MAPS_DIR = os.path.join(COMMON_DL_DIR, 'maps')
 TOOLING_DIR = os.path.join(ROOT_DIR, 'tooling')
 TOOLING_WIN_DIR = os.path.join(ROOT_DIR, 'tooling_windows')


### PR DESCRIPTION
## This PR…

- moves the `common_download` and `output` dir one level up to be release independent
- closes #88 

## Considerations and implementations

Users using different versions or updating to a newer version do not have to copy the relevant files from one downloaded wahooMapsCreator directory to the other.

This is the resulting folder structure:
```
wahooMapsCreator_v1.0.0
│   README.md
│   wahoo_map_creator.py
│   ...

wahooMapsCreator_v1.1.0
│   README.md
│   wahoo_map_creator.py
│   ...

wahooMapsCreator_download
│    geofabrik.json
│
└───maps
│   │      malta-latest.osm.pbf
│   │      ...
│
└───land-polygons-split-4326
    │      land_polygons.shp
    │      ...

wahooMapsCreator_output
│    malta.zip
│    ...
│
└───138
    │      ...
```


## How to test

1. Have two versions of wahooMapsCreator (this branch) in the same directory
2. Use the two wahooMapsCreator's one after another
3. Check if the downloaded and created folders are on the same level as the wahooMapsCreator directories
- dir `wahooMapsCreator_output`
- dir `wahooMapsCreator_download`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
