### PR TITLE
[FIX] Release all dist/*.zip files as Assets (also cruiser!) and include moved files (corrects #90)

### DIFF
--- a/.github/workflows/git-release-pre.yml
+++ b/.github/workflows/git-release-pre.yml
@@ -28,7 +28,7 @@ jobs:
           ALLOW_EMPTY_CHANGELOG: true
         with:
           args: |
-            dist/wahooMapsCreator-*.zip
+            dist/*.zip
             darwin-amd64.zip
             linux-amd64.zip
             windows-amd64.zip

--- a/.github/workflows/git-release-test.yml
+++ b/.github/workflows/git-release-test.yml
@@ -33,7 +33,7 @@ jobs:
           UNRELEASED: "update"
         with:
           args: |
-            dist/wahooMapsCreator-*.zip
+            dist/*.zip
             darwin-amd64.zip
             linux-amd64.zip
             windows-amd64.zip

--- a/.github/workflows/git-release.yml
+++ b/.github/workflows/git-release.yml
@@ -27,7 +27,7 @@ jobs:
           RELEASE_NAME_PREFIX: "Release "
         with:
           args: |
-            dist/wahooMapsCreator-*.zip
+            dist/*.zip
             darwin-amd64.zip
             linux-amd64.zip
             windows-amd64.zip

--- a/copyFilesToDist.sh
+++ b/copyFilesToDist.sh
@@ -27,8 +27,8 @@ mkdir -p ./tooling
 
 # copy files into dist-folder
 cp -a ../../common_python/*.py ./common_python/
-
 cp -a ../../common_resources/*.xml ./common_resources/
+cp -a ../../common_resources/*.osm ../../common_resources/*.py ./common_resources/
 cp -a ../../common_resources/json/ ./common_resources/json
 cp -a ../../common_resources/tag_wahoo_adjusted/ ./common_resources/tag_wahoo_adjusted
 cp -a ../../common_resources/tag_wahoo_initial/ ./common_resources/tag_wahoo_initial


### PR DESCRIPTION
## This PR…

corrects #90

## Considerations and implementations

- not only the wahooMapsCreator .zip files but also the cruiser .zip file is added as asset to the release
- moved files from `tooling` to `common_resources` are now also included in the wahooMapscreator .zip files

## How to test

-

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
