### PR TITLE
[BREAKING] X/Y coordinates can be given as input parameters (e.g. for testing!) & refactoring of GUI & CLI processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ osmconvert_tempfile.*
 **/__pycache__/*
 **/*.pyc
 **/*.DS_Store
+**/*.py*.tmp
 
 # mac/unix
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -184,6 +184,18 @@
             "args": [
                 "gui"
             ]
+        },
+        {
+            "name": "new cli/gui: 133/88",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceRoot}/wahoo_map_creator.py",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-xy",
+                "133/88"
+            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,8 @@
             "program": "${workspaceRoot}/wahoo_map_creator.py",
             "console": "integratedTerminal",
             "args": [
+                "cli",
+                "-fi",
                 "${workspaceRoot}/tests/json/germany-only1.json",
                 "-md",
                 "100",
@@ -23,6 +25,8 @@
             "program": "${workspaceRoot}/wahoo_map_creator.py",
             "console": "integratedTerminal",
             "args": [
+                "cli",
+                "-fi",
                 "${workspaceRoot}/tests/json/germany-only1.json",
                 "-tag",
                 "tag-wahoo-hidrive2.xml",
@@ -40,6 +44,8 @@
             "program": "${workspaceRoot}/wahoo_map_creator.py",
             "console": "integratedTerminal",
             "args": [
+                "cli",
+                "-fi",
                 "${workspaceRoot}/tests/json/germany-only2.json",
                 "-md",
                 "100",
@@ -55,6 +61,8 @@
             "program": "${workspaceRoot}/wahoo_map_creator.py",
             "console": "integratedTerminal",
             "args": [
+                "cli",
+                "-co",
                 "germany"
             ]
         },
@@ -65,6 +73,8 @@
             "program": "${workspaceRoot}/wahoo_map_creator.py",
             "console": "integratedTerminal",
             "args": [
+                "cli",
+                "-co",
                 "malta",
                 "-tag",
                 "tag-wahoo.xml",
@@ -81,6 +91,8 @@
             "program": "${workspaceRoot}/wahoo_map_creator.py",
             "console": "integratedTerminal",
             "args": [
+                "cli",
+                "-co",
                 "malta",
                 "-tag",
                 "tag-wahoo.xml",
@@ -97,7 +109,9 @@
             "request": "launch",
             "program": "${workspaceRoot}/wahoo_map_creator.py",
             "console": "integratedTerminal",
-            "args": []
+            "args": [
+                "gui"
+            ]
         },
         {
             "name": "cli help",
@@ -116,6 +130,8 @@
             "program": "${workspaceRoot}/wahoo_map_creator.py",
             "console": "integratedTerminal",
             "args": [
+                "cli",
+                "-co",
                 "malta",
                 "-tag",
                 "tag-wahoo.xml",
@@ -132,6 +148,8 @@
             "program": "${workspaceRoot}/wahoo_map_creator.py",
             "console": "integratedTerminal",
             "args": [
+                "cli",
+                "-co",
                 "liechtenstein",
                 "-tag",
                 "tag-wahoo.xml",
@@ -164,29 +182,7 @@
             ]
         },
         {
-            "name": "new cli/gui: CLI malta",
-            "type": "python",
-            "request": "launch",
-            "program": "${workspaceRoot}/wahoo_map_creator.py",
-            "console": "integratedTerminal",
-            "args": [
-                "cli",
-                "-co",
-                "malta"
-            ]
-        },
-        {
-            "name": "new cli/gui: GUI",
-            "type": "python",
-            "request": "launch",
-            "program": "${workspaceRoot}/wahoo_map_creator.py",
-            "console": "integratedTerminal",
-            "args": [
-                "gui"
-            ]
-        },
-        {
-            "name": "new cli/gui: 133/88",
+            "name": "x/y: 133/88",
             "type": "python",
             "request": "launch",
             "program": "${workspaceRoot}/wahoo_map_creator.py",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -171,7 +171,7 @@
             "console": "integratedTerminal",
             "args": [
                 "cli",
-                "-country",
+                "-co",
                 "malta"
             ]
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -162,6 +162,28 @@
                 "C:\\VSCode\\python\\wahooMapsCreator\\output\\138\\100\\land.shp",
                 "C:\\VSCode\\python\\wahooMapsCreator\\output\\138\\100\\land1.osm"
             ]
+        },
+        {
+            "name": "new cli/gui: CLI malta",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceRoot}/wahoo_map_creator.py",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-country",
+                "malta"
+            ]
+        },
+        {
+            "name": "new cli/gui: GUI",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceRoot}/wahoo_map_creator.py",
+            "console": "integratedTerminal",
+            "args": [
+                "gui"
+            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -192,6 +192,30 @@
                 "-xy",
                 "133/88"
             ]
+        },
+        {
+            "name": "x/y: 138/100 (malta)",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceRoot}/wahoo_map_creator.py",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-xy",
+                "138/100"
+            ]
+        },
+        {
+            "name": "x/y: 138/100,133/88 (two tiles)",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceRoot}/wahoo_map_creator.py",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-xy",
+                "138/100,133/88"
+            ]
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Using Anaconda to setup a virtual Python environment is the fastest way to get w
 ## Run wahooMapsCreator
 via GUI
 ```
-python wahoo_map_creator.py
+python wahoo_map_creator.py gui
 ```
 via CLI
 ```
-python wahoo_map_creator.py malta
+python wahoo_map_creator.py cli -co malta
 ```
 
 A detailled description of the usage is documented [:computer: here](docs/USAGE.md#usage-of-wahoomapscreator)

--- a/common_python/file_directory_functions.py
+++ b/common_python/file_directory_functions.py
@@ -84,11 +84,12 @@ def create_empty_directories(tiles_from_json):
             os.makedirs(outdir)
 
 
-def read_json_file(json_file_path):
+def read_json_file(json_file_path, logging = True):
     """
     read the tiles from the given json file
     """
-    print('\n# Read json file')
+    if logging:
+        print('\n# Read json file')
 
     with open(json_file_path) as json_file:
         tiles_from_json = json.load(json_file)
@@ -97,10 +98,11 @@ def read_json_file(json_file_path):
         print('! Json file could not be opened.')
         sys.exit()
 
-    # logging
-    print(
-        f'+ Use json file {json_file.name} with {len(tiles_from_json)} tiles')
-    print('# Read json file: OK')
+    if logging:
+        # logging
+        print(
+            f'+ Use json file {json_file.name} with {len(tiles_from_json)} tiles')
+        print('# Read json file: OK')
 
     return tiles_from_json
 

--- a/common_python/file_directory_functions.py
+++ b/common_python/file_directory_functions.py
@@ -6,6 +6,7 @@ constants, functions and object for file-system operations
 # import official python packages
 import json
 import os
+from os.path import isfile, join
 import subprocess
 import sys
 import zipfile
@@ -124,3 +125,42 @@ def write_to_file(file_path, request):
     with open(file_path, 'wb') as file_handle:
         for chunk in request.iter_content(chunk_size=1024*100):
             file_handle.write(chunk)
+
+
+def get_folders_in_folder(folder):
+    """
+    return foldernames of given folder without path as list
+    """
+    onlyfolders = [f for f in os.listdir(
+        folder) if not isfile(join(folder, f))]
+
+    return onlyfolders
+
+
+def get_files_in_folder(folder):
+    """
+    return filenames of given folder without path as list
+    """
+    onlyfiles = [f for f in os.listdir(folder) if isfile(join(folder, f))]
+
+    return onlyfiles
+
+
+def get_filenames_of_jsons_in_folder(folder):
+    """
+    return json-file filenames of given folder without path as list
+    """
+    # log.debug('function: get_filenames_of_jsons_in_folder')
+    # log.debug('# Read available json files from directory: "%s"', folder)
+
+    json_files = []
+
+    for file in get_files_in_folder(folder):
+        if file.endswith('.json'):
+            # filename = file.split('.')[0]
+            filename = os.path.splitext(file)[0]
+            json_files.extend([filename])
+
+    # log.debug('# Read available json files from directory: "%s" : OK', folder)
+
+    return json_files

--- a/common_python/input.py
+++ b/common_python/input.py
@@ -20,9 +20,6 @@ def process_call_of_the_tool():
     """
     process CLI arguments
     """
-
-    o_input_data = InputData()
-
     # input argument creation and processing
     desc = "Create up-to-date maps for your Wahoo ELEMNT and Wahoo ELEMNT BOLT"
     parser_top = argparse.ArgumentParser(description=desc)
@@ -58,7 +55,7 @@ def process_call_of_the_tool():
     options_args = parser_cli.add_argument_group(
         title='Options', description='Options for map generation')
     # Maximum age of source maps or land shape files before they are redownloaded
-    options_args.add_argument('-md', '--maxdays', type=int, default=o_input_data.max_days_old,
+    options_args.add_argument('-md', '--maxdays', type=int, default=InputData().max_days_old,
                               help="maximum age of source maps and other files")
     # Calculate also border countries of input country or not
     options_args.add_argument('-bc', '--bordercountries', action='store_true',
@@ -77,7 +74,7 @@ def process_call_of_the_tool():
     options_args.add_argument('-c', '--cruiser', action='store_true',
                               help="save uncompressed maps for Cruiser")
     # specify the file with tags to keep in the output // file needs to be in common_resources
-    options_args.add_argument('-tag', '--tag_wahoo_xml', default=o_input_data.tag_wahoo_xml,
+    options_args.add_argument('-tag', '--tag_wahoo_xml', default=InputData().tag_wahoo_xml,
                               help="file with tags to keep in the output")
     # specify the file with tags to keep in the output // file needs to be in common_resources
     options_args.add_argument('-om', '--only_merge', action='store_true',
@@ -99,8 +96,7 @@ def process_call_of_the_tool():
             sys.exit("GUI can not be startet because no graphical interface is available. Start with 'wahoo_maps_creator.py cli -h' or 'wahoo_maps_creator.py -h' to see command line options.")
             return
 
-        o_input = GuiInput(InputData())
-        o_input_data = o_input.start_gui()
+        o_input_data = GuiInput().start_gui()
 
     # cli processing
     else:
@@ -193,8 +189,8 @@ class GuiInput(tk.Tk):
     This is the class to proces user-input via GUI
     """
 
-    def __init__(self, oInputData, *args, **kwargs):
-        self.o_input_data = oInputData
+    def __init__(self, *args, **kwargs):
+        self.o_input_data = InputData()
 
         tk.Tk.__init__(self, *args, **kwargs)
 

--- a/common_python/input.py
+++ b/common_python/input.py
@@ -178,7 +178,7 @@ class InputData():
         - file with tile coordinates
         If not, depending on the import parameter, the
         """
-        if not (self.country != "none" and self.country != "") or not (self.xy_coordinates != "none" and self.xy_coordinates != "") or not (self.tile_file != "none" and self.tile_file != ""):
+        if (self.country in ('None', '') and self.xy_coordinates in ('None', '') and self.tile_file in ('None', '')):
             if issue_message:
                 sys.exit("Nothing to do. Start with -h or --help to see command line options."
                          "Or in the GUI select a country to create maps for.")

--- a/common_python/input.py
+++ b/common_python/input.py
@@ -49,7 +49,7 @@ def process_call_of_the_tool():
         "-co", "--country", help="country to generate maps for")
     # X/Y coordinates to create maps for
     primary_args_excl.add_argument(
-        "-xy", "--xy_coordinates", help="x/y coordinates to generate maps for")
+        "-xy", "--xy_coordinates", help="x/y coordinates to generate maps for. Example: 133/88")
     # file to create maps for
     primary_args_excl.add_argument(
         "-fi", "--tile_file", help="file with tiles to generate maps for")

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -134,10 +134,6 @@ class OsmMaps:
             # # option 3a: use Geofabrik-URL to get the relevant tiles
             if self.o_input_data.geofabrik_tiles:
                 sys.exit("X/Y coordinated via Geofabrik not implemented now")
-                # self.force_processing = self.o_downloader.check_and_download_geofabrik_if_needed()
-
-                # o_geofabrik = Geofabrik(self.o_input_data.country)
-                # self.tiles = o_geofabrik.get_tiles_of_country()
 
             # option 3b: use static json files in the repo to get relevant tiles
             else:
@@ -146,8 +142,8 @@ class OsmMaps:
                 self.tiles.append(get_tile_by_xy_coordinate(
                     x_coord, y_coord))
 
-                # country name are the X/Y coordinates if that works?!
-                self.country_name = self.o_input_data.xy_coordinates
+                # country name are the X/Y coordinates separated by minus
+                self.country_name = f'{x_coord}-{y_coord}'
 
             # calc border country when input X/Y coordinates
             calc_border_countries = True

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -26,7 +26,6 @@ def get_xy_coordinate_from_input(input_xy_coordinates):
     """
     get tile from json files by given X/Y coordinate
     """
-
     splitted = input_xy_coordinates.split("/")
 
     if len(splitted) == 2:
@@ -37,7 +36,6 @@ def get_tile_by_xy_coordinate(x_coord, y_coord):
     """
     get tile from json files by given X/Y coordinate
     """
-
     # go throught all files in all folders of the "json" directory
     file_path_jsons = os.path.join(fd_fct.COMMON_DIR, 'json')
     for folder in fd_fct.get_folders_in_folder(file_path_jsons):
@@ -85,10 +83,6 @@ class OsmMaps:
         """
         get relevant tiles for given input and calc border countries of these tiles
         """
-
-        # logging
-        # print(f'+ Input country or json file: {input_argument}.')
-
         # option 1: have a .json file as input parameter
         if self.o_input_data.tile_file:
             # logging

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -54,7 +54,7 @@ def get_tile_by_one_xy_combination_from_jsons(xy_combination):
 
             # get content of json in folder
             content = fd_fct.read_json_file(
-                os.path.join(file_path_jsons, folder, file + '.json'))
+                os.path.join(file_path_jsons, folder, file + '.json'), logging = False)
 
             # check tiles values against input x/y combination
             for tile in content:

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -50,42 +50,53 @@ class OsmMaps:
             self.osmconvert_path = os.path.join(
                 fd_fct.TOOLING_WIN_DIR, 'osmconvert64-0.8.8p')
 
-    def process_input(self, input_argument, calc_border_countries):
+    def process_input(self, calc_border_countries):
         """
         get relevant tiles for given input and calc border countries of these tiles
         """
 
         # logging
-        print(f'+ Input country or json file: {input_argument}.')
+        # print(f'+ Input country or json file: {input_argument}.')
 
         # option 1: have a .json file as input parameter
-        if os.path.isfile(input_argument):
-            self.tiles = fd_fct.read_json_file(input_argument)
+        if self.o_input_data.tile_file:
+            # logging
+            print(f'+ Input json file: {self.o_input_data.tile_file}.')
 
-            # country name is the last part of the input filename
-            self.country_name = os.path.split(input_argument)[1][:-5]
+            if (os.path.isfile(self.o_input_data.tile_file)):
+                self.tiles = fd_fct.read_json_file(self.o_input_data.tile_file)
+
+                # country name is the last part of the input filename
+                self.country_name = os.path.split(
+                    self.o_input_data.tile_file)[1][:-5]
+
+                # calc border country when input tiles via json file
+                calc_border_countries = True
 
         # option 2: input a country as parameter, e.g. germany
-        else:
+        elif self.o_input_data.country:
+            # logging
+            print(f'+ Input country : {self.o_input_data.country}.')
+
             # option 2a: use Geofabrik-URL to calculate the relevant tiles
             if self.o_input_data.geofabrik_tiles:
                 self.force_processing = self.o_downloader.check_and_download_geofabrik_if_needed()
 
-                o_geofabrik = Geofabrik(input_argument)
+                o_geofabrik = Geofabrik(self.o_input_data.country)
                 self.tiles = o_geofabrik.get_tiles_of_country()
 
             # option 2b: use static json files in the repo to calculate relevant tiles
             else:
                 json_file_path = os.path.join(fd_fct.COMMON_DIR, 'json',
-                                              const_fct.get_region_of_country(input_argument), input_argument + '.json')
+                                              const_fct.get_region_of_country(self.o_input_data.country), self.o_input_data.country + '.json')
                 self.tiles = fd_fct.read_json_file(json_file_path)
 
             # country name is the input argument
-            self.country_name = input_argument
+            self.country_name = self.o_input_data.country
 
         # Build list of countries needed
         self.border_countries = {}
-        if calc_border_countries or os.path.isfile(input_argument):
+        if calc_border_countries:
             self.calc_border_countries()
         else:
             self.border_countries[self.country_name] = {}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -5,7 +5,11 @@ wahooMapsCreator can be used in two different ways:
 
 Both ways support the same arguments to be used for the map-creation process. You can choose the arguments via GUI or as [CLI-arguments](#advanced-cli-usage).
 
-### GUI (Graphical User Interface)
+## Run wahooMapsCreator for your country
+It might be a good idea to run wahooMapsCreator first for a small country e.g. Malta to check if everything is running fine.
+In a next step you can run it for your own country.
+
+## GUI (Graphical User Interface)
 
 From the `root` folder of wahooMapsCreator, run:
   - `python wahoo_map_creator.py gui`
@@ -14,7 +18,7 @@ Set your arguments as required via the window:
 
 <img src="https://github.com/treee111/wahooMapsCreator/blob/develop/docs/gui.png" alt="wahooMapsCreator GUI" width=35%>
 
-### CLI (Command Line Interface)
+## CLI (Command Line Interface)
 
 From the `root` folder of wahooMapsCreator, run:
 - `python wahoo_map_creator.py cli -co <country_name>`
@@ -23,19 +27,28 @@ Examples:
 - for Malta: `python wahoo_map_creator.py cli -co malta`
 - for Ireland: `python wahoo_map_creator.py cli -co ireland`
 
-### Run wahooMapsCreator for your country
-It might be a good idea to run wahooMapsCreator first for a small country e.g. Malta to check if everything is running fine.
-In a next step you can run it for your own country.
-
-### Advanced CLI-Usage
+## Advanced CLI-Usage
 The script supports many arguments via command line.
 For a list of all supported arguments, run:
 - `python wahoo_map_creator.py cli -h`
 
-Examples:
+### Main arguments
+**Create maps for a country**
+- `python wahoo_map_creator.py cli -co <country>`
+
+**Create maps for X/Y coordinates**
+
+In particular for testing adjustments in configuration-files or coding it is helpful to create maps for only one tile or a handful of tiles!
+
+To create maps for only one tile and not a whole country, one can use the X/Y coordinates of that tile. X/Y coordinates can be retrieved from this in zoom-level 8: [link](http://tools.geofabrik.de/map/#8/50.3079/8.8026&type=Geofabrik_Standard&grid=1). 
+- `python wahoo_map_creator.py cli -xy <xy_coordinate,xy_coordinate>`
+
+### Examples
 - for Malta, download new maps if existing maps are older than 100 days and process files even if files exist
   - `python wahoo_map_creator.py cli -co malta -md 100 -fp`
 - for Germany, download and process whole tiles which involves other countries than the given
   - `python wahoo_map_creator.py cli -co germany -bc`
-- to create maps for only one tile and not a whole country, one can use the X/Y coordinates of that tile. X/Y coordinates can be retrieved from this [link]([#advanced-cli-usage](http://tools.geofabrik.de/map/#8/50.3079/8.8026&type=Geofabrik_Standard&grid=1)) in zoom-level 8.
+- to create maps for only one tile
   - `python wahoo_map_creator.py cli -xy 134/88`
+- for multiple tiles
+  - `python wahoo_map_creator.py cli -xy 134/88,133/88`

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -8,7 +8,7 @@ Both ways support the same arguments to be used for the map-creation process. Yo
 ### GUI (Graphical User Interface)
 
 From the `root` folder of wahooMapsCreator, run:
-  - `python wahoo_map_creator.py`
+  - `python wahoo_map_creator.py gui`
 
 Set your arguments as required via the window:
 
@@ -17,23 +17,25 @@ Set your arguments as required via the window:
 ### CLI (Command Line Interface)
 
 From the `root` folder of wahooMapsCreator, run:
-- `python wahoo_map_creator.py <country_name>`
+- `python wahoo_map_creator.py cli -co <country_name>`
 
 Examples:
-- for Malta: `python wahoo_map_creator.py malta`
-- for Ireland: `python wahoo_map_creator.py ireland`
+- for Malta: `python wahoo_map_creator.py cli -co malta`
+- for Ireland: `python wahoo_map_creator.py cli -co ireland`
 
 ### Run wahooMapsCreator for your country
 It might be a good idea to run wahooMapsCreator first for a small country e.g. Malta to check if everything is running fine.
 In a next step you can run it for your own country.
 
 ### Advanced CLI-Usage
-The script supports many arguments.
+The script supports many arguments via command line.
 For a list of all supported arguments, run:
-- `python wahoo_map_creator.py -h`
+- `python wahoo_map_creator.py cli -h`
 
 Examples:
 - for Malta, download new maps if existing maps are older than 100 days and process files even if files exist
-  - `python wahoo_map_creator.py malta -md 100 -fp`
+  - `python wahoo_map_creator.py cli -co malta -md 100 -fp`
 - for Germany, download and process whole tiles which involves other countries than the given
-  - `python wahoo_map_creator.py germany -bc`
+  - `python wahoo_map_creator.py cli -co germany -bc`
+- to create maps for only one tile and not a whole country, one can use the X/Y coordinates of that tile. X/Y coordinates can be retrieved from this [link]([#advanced-cli-usage](http://tools.geofabrik.de/map/#8/50.3079/8.8026&type=Geofabrik_Standard&grid=1)) in zoom-level 8.
+  - `python wahoo_map_creator.py cli -xy 134/88`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,15 +13,30 @@ class TestCli(unittest.TestCase):
     tests for the CLI of the python file
     """
 
-    def test_cli_help(self):
+    def test_top_parser_help(self):
         """
-        tests, if help can be called
+        tests, if help of top parser can be called
         """
 
-        if platform.system() == "Windows":
-            result = os.system("python wahoo_map_creator.py -h")
-        else:
-            result = os.system("python3 wahoo_map_creator.py -h")
+        result = os.system("python wahoo_map_creator.py -h")
+
+        self.assertEqual(result, 0)
+
+    def test_cli_help(self):
+        """
+        tests, if CLI help can be called
+        """
+
+        result = os.system("python wahoo_map_creator.py cli -h")
+
+        self.assertEqual(result, 0)
+
+    def test_gui_help(self):
+        """
+        tests, if GUI help can be called
+        """
+
+        result = os.system("python wahoo_map_creator.py gui -h")
 
         self.assertEqual(result, 0)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@ tests for the python file
 """
 import os
 import unittest
-import platform
 
 # import custom python packages
 

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -131,7 +131,7 @@ class TestOsmMaps(unittest.TestCase):
                            'right': 15.46875, 'bottom': 35.46067, 'countries': ['malta']}]
         self.calculate_tiles_via_static_json('malta', expected_tiles)
 
-    def process_and_check_border_countries(self, inp_val, calc_border_countries, exp_result, inp_mode):
+    def process_and_check_border_countries(self, inp_val, calc_border_c, exp_result, inp_mode):
         """
         helper method to process a country or json file and check the calculated border countries
         """
@@ -140,7 +140,7 @@ class TestOsmMaps(unittest.TestCase):
         elif inp_mode == 'json_file':
             self.o_osm_maps.o_input_data.tile_file = inp_val
 
-        self.o_osm_maps.process_input(calc_border_countries)
+        self.o_osm_maps.process_input(calc_border_c)
         result = self.o_osm_maps.border_countries
 
         self.assertEqual(result, exp_result)

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -10,6 +10,7 @@ import unittest
 
 from common_python.osm_maps_functions import OsmMaps
 from common_python.osm_maps_functions import get_tile_by_xy_coordinate
+from common_python.osm_maps_functions import get_xy_coordinate_from_input
 from common_python.input import InputData
 from common_python import file_directory_functions as fd_fct
 from common_python import constants_functions as const_fct
@@ -155,6 +156,33 @@ class TestOsmMaps(unittest.TestCase):
         tiles = fd_fct.read_json_file(json_file_path)
 
         self.assertEqual(tiles, expected_result)
+
+    def test_splitting_of_xy_coordinate(self):
+        """
+        use static json files in the repo to calculate relevant tiles
+        """
+        x_coord, y_coord = get_xy_coordinate_from_input("133/88")
+
+        self.assertEqual(x_coord, 133)
+        self.assertEqual(y_coord, 88)
+
+        x_coord, y_coord = get_xy_coordinate_from_input("11/92")
+
+        self.assertEqual(x_coord, 11)
+        self.assertEqual(y_coord, 92)
+
+    def test_get_tile_via_xy_coordinate(self):
+        """
+        use static json files in the repo to calculate relevant tiles
+        """
+        tile = get_tile_by_xy_coordinate(133, 88)
+
+        # json_file_path = os.path.join(fd_fct.COMMON_DIR, 'json',
+        #                               const_fct.get_region_of_country(country), country + '.json')
+        expected_result = fd_fct.read_json_file(
+            '/Users/benjamin/VSCode/wahooMapsCreator/tests/json/germany-only9.json')
+
+        self.assertEqual(tile, expected_result[3])
 
 
 if __name__ == '__main__':

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -45,7 +45,6 @@ class TestOsmMaps(unittest.TestCase):
         Test a json file as input to the wahooMapsCreator
         check, if the given input-parameter is saved to the OsmMaps instance
         """
-
         json_file_path = os.path.join(
             self.file_path_test_json, 'germany-only1.json')
 
@@ -132,20 +131,19 @@ class TestOsmMaps(unittest.TestCase):
                            'right': 15.46875, 'bottom': 35.46067, 'countries': ['malta']}]
         self.calculate_tiles_via_static_json('malta', expected_tiles)
 
-    def process_and_check_border_countries(self, country, calc_border_countries, expected_result, input_mode):
+    def process_and_check_border_countries(self, inp_val, calc_border_countries, exp_result, inp_mode):
         """
-        helper method to check a country without border countries
+        helper method to process a country or json file and check the calculated border countries
         """
-
-        if input_mode == 'country':
-            self.o_osm_maps.o_input_data.country = country
-        elif input_mode == 'json_file':
-            self.o_osm_maps.o_input_data.tile_file = country
+        if inp_mode == 'country':
+            self.o_osm_maps.o_input_data.country = inp_val
+        elif inp_mode == 'json_file':
+            self.o_osm_maps.o_input_data.tile_file = inp_val
 
         self.o_osm_maps.process_input(calc_border_countries)
         result = self.o_osm_maps.border_countries
 
-        self.assertEqual(result, expected_result)
+        self.assertEqual(result, exp_result)
 
     def calculate_tiles_via_static_json(self, country, expected_result):
         """
@@ -177,8 +175,6 @@ class TestOsmMaps(unittest.TestCase):
         """
         tile = get_tile_by_xy_coordinate(133, 88)
 
-        # json_file_path = os.path.join(fd_fct.COMMON_DIR, 'json',
-        #                               const_fct.get_region_of_country(country), country + '.json')
         expected_result = fd_fct.read_json_file(
             '/Users/benjamin/VSCode/wahooMapsCreator/tests/json/germany-only9.json')
 

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -9,8 +9,8 @@ import unittest
 # sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from common_python.osm_maps_functions import OsmMaps
-from common_python.osm_maps_functions import get_tile_by_xy_coordinate
-from common_python.osm_maps_functions import get_xy_coordinate_from_input
+from common_python.osm_maps_functions import get_tile_by_one_xy_combination_from_jsons
+from common_python.osm_maps_functions import get_xy_coordinates_from_input
 from common_python.input import InputData
 from common_python import file_directory_functions as fd_fct
 from common_python import constants_functions as const_fct
@@ -155,25 +155,37 @@ class TestOsmMaps(unittest.TestCase):
 
         self.assertEqual(tiles, expected_result)
 
-    def test_splitting_of_xy_coordinate(self):
+    def test_splitting_of_single_xy_coordinate(self):
         """
         use static json files in the repo to calculate relevant tiles
         """
-        x_coord, y_coord = get_xy_coordinate_from_input("133/88")
+        xy_tuple = get_xy_coordinates_from_input("133/88")
 
-        self.assertEqual(x_coord, 133)
-        self.assertEqual(y_coord, 88)
+        self.assertEqual(xy_tuple, [{"x": 133, "y": 88}])
 
-        x_coord, y_coord = get_xy_coordinate_from_input("11/92")
+        xy_tuple = get_xy_coordinates_from_input("11/92")
 
-        self.assertEqual(x_coord, 11)
-        self.assertEqual(y_coord, 92)
+        self.assertEqual(xy_tuple, [{"x": 11, "y": 92}])
+
+        xy_tuple = get_xy_coordinates_from_input("138/100")
+        expected_result = [{"x": 138, "y": 100}]
+
+        self.assertEqual(xy_tuple, expected_result)
+
+    def test_splitting_of_multiple_xy_coordinate(self):
+        """
+        use static json files in the repo to calculate relevant tiles
+        """
+        xy_tuple = get_xy_coordinates_from_input("133/88,138/100")
+        expected_result = [{"x": 133, "y": 88}, {"x": 138, "y": 100}]
+
+        self.assertEqual(xy_tuple, expected_result)
 
     def test_get_tile_via_xy_coordinate(self):
         """
         use static json files in the repo to calculate relevant tiles
         """
-        tile = get_tile_by_xy_coordinate(133, 88)
+        tile = get_tile_by_one_xy_combination_from_jsons({"x": 133, "y": 88})
 
         expected_result = fd_fct.read_json_file(
             '/Users/benjamin/VSCode/wahooMapsCreator/tests/json/germany-only9.json')

--- a/wahoo_map_creator.py
+++ b/wahoo_map_creator.py
@@ -6,7 +6,7 @@ executable file to create up-to-date map-files for the Wahoo ELEMNT and Wahoo EL
 # import official python packages
 
 # import custom python packages
-from common_python.input import Input
+from common_python.input import process_call_of_the_tool
 from common_python.file_directory_functions import initialize_work_directories
 from common_python.osm_maps_functions import OsmMaps
 
@@ -15,12 +15,8 @@ from common_python.osm_maps_functions import OsmMaps
 # ! means error
 # + means additional comment in a working-unit
 
-oInput = Input()
-
-if oInput.gui_mode:
-    oInputData = oInput.start_gui()
-else:
-    oInputData = oInput.cli_arguments()
+# handle GUI and CLI processing via a function and different cli-calls
+oInputData = process_call_of_the_tool()
 
 # Is there something to do?
 oInputData.is_required_input_given_or_exit(True)

--- a/wahoo_map_creator.py
+++ b/wahoo_map_creator.py
@@ -28,7 +28,7 @@ oOSMmaps = OsmMaps(oInputData)
 # Read json file
 # Check for expired land polygons file and download, if too old
 # Check for expired .osm.pbf files and download, if too old
-oOSMmaps.process_input(oInputData.country, oInputData.border_countries)
+oOSMmaps.process_input(oInputData.border_countries)
 oOSMmaps.check_and_download_files()
 
 

--- a/wahoo_map_creator.py
+++ b/wahoo_map_creator.py
@@ -15,11 +15,11 @@ from common_python.osm_maps_functions import OsmMaps
 # ! means error
 # + means additional comment in a working-unit
 
-# handle GUI and CLI processing via a function and different cli-calls
+# handle GUI and CLI processing via one function and different cli-calls
 oInputData = process_call_of_the_tool()
 
 # Is there something to do?
-oInputData.is_required_input_given_or_exit(True)
+oInputData.is_required_input_given_or_exit(issue_message=True)
 
 initialize_work_directories()
 


### PR DESCRIPTION
## This PR…

- makes it possible to provide X/Y coordinates via command line as input parameter to create the corresponding map

## Considerations and implementations

This PR brings a foundation to implement #100 and #89 by
- refactoring the argparse input coding to be future-proof
  - subparsers (and therefore subcommands) for GUI and CLI start of the tool
  - differentiate between the three possible primary inputs for CLI processing (country-name, X/Y coordinates, json file with tiles) in cli help and program coding

## How to test

1. run tool via CLI with one X/Y coordinate and multiple X/Y coordinates
   - one country involved
   - multiple countries involved
2. run tool via CLI for a country
3. run tool via GUI for a country
4. check README and documentation

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
