### PR TITLE
[BREAKING] default "process border countries" to yes in GUI and CLI

### DIFF
--- a/common_python/input.py
+++ b/common_python/input.py
@@ -57,9 +57,9 @@ def process_call_of_the_tool():
     # Maximum age of source maps or land shape files before they are redownloaded
     options_args.add_argument('-md', '--maxdays', type=int, default=InputData().max_days_old,
                               help="maximum age of source maps and other files")
-    # Calculate also border countries of input country or not
-    options_args.add_argument('-bc', '--bordercountries', action='store_true',
-                              help="process whole tiles which involve border countries")
+    # Do not calculate border countries of input country
+    options_args.add_argument('-nbc', '--bordercountries', action='store_false',
+                              help="do not process border countries of tiles involving more than one country")
     # Force download of source maps and the land shape file
     # If False use Max_Days_Old to check for expired maps
     # If True force redownloading of maps and landshape
@@ -151,7 +151,7 @@ class InputData():
 
         self.force_download = False
         self.force_processing = False
-        self.border_countries = False
+        self.border_countries = True
         self.save_cruiser = False
         self.only_merge = False
 

--- a/common_python/input.py
+++ b/common_python/input.py
@@ -106,7 +106,7 @@ def process_call_of_the_tool():
         o_input_data.tile_file = args.tile_file
         o_input_data.max_days_old = args.maxdays
 
-        o_input_data.border_countries = args.bordercountries
+        o_input_data.process_border_countries = args.bordercountries
         o_input_data.force_download = args.forcedownload
         o_input_data.force_processing = args.forceprocessing
         o_input_data.geofabrik_tiles = args.geofabrik_tiles
@@ -151,7 +151,7 @@ class InputData():
 
         self.force_download = False
         self.force_processing = False
-        self.border_countries = True
+        self.process_border_countries = True
         self.save_cruiser = False
         self.only_merge = False
 
@@ -261,7 +261,7 @@ class GuiInput(tk.Tk):
 
         self.o_input_data.force_download = tab1.third.checkb_download.get()
         self.o_input_data.force_processing = tab1.third.checkb_processing_val.get()
-        self.o_input_data.border_countries = tab1.third.checkb_border_countries_val.get()
+        self.o_input_data.process_border_countries = tab1.third.checkb_border_countries_val.get()
         self.o_input_data.geofabrik_tiles = tab1.third.checkb_geofabrik_tiles_val.get()
 
         self.o_input_data.only_merge = tab2.first.checkb_only_merge_val.get()
@@ -357,7 +357,7 @@ class CheckbuttonsTab1(tk.Frame):
         self.chk_force_download.bind(
             "<Button-1>", self.controller.switch_reload)
 
-        self.checkb_border_countries_val = create_checkbox(self, oInputData.border_countries,
+        self.checkb_border_countries_val = create_checkbox(self, oInputData.process_border_countries,
                                                            "Process border countries", 0)
         self.chk_force_download.grid(
             column=0, row=1, sticky=tk.W, padx=15, pady=5)

--- a/common_python/osm_maps_functions.py
+++ b/common_python/osm_maps_functions.py
@@ -188,7 +188,7 @@ class OsmMaps:
         # Build list of countries needed
         self.border_countries = {}
         if calc_border_countries:
-            self.calc_border_countries()
+            self.calc_border_countries(calc_border_countries)
         else:
             self.border_countries[self.country_name] = {}
 
@@ -208,10 +208,14 @@ class OsmMaps:
         else:
             self.force_processing = False
 
-    def calc_border_countries(self):
+    def calc_border_countries(self, calc_border_countries):
         """
         calculate relevant border countries for the given tiles
         """
+
+        log.info('-' * 80)
+        if calc_border_countries:
+            log.info('# Determine involved/border countries')
 
         # Build list of countries needed
         for tile in self.tiles:
@@ -219,9 +223,13 @@ class OsmMaps:
                 if country not in self.border_countries:
                     self.border_countries[country] = {}
 
-        log.info('+ Count of Border countries: %s', len(self.border_countries))
+        # log.info('+ Count of involved countries: %s',
+        #          len(self.border_countries))
         for country in self.border_countries:
-            log.info('+ Border country: %s', country)
+            log.info('+ Involved country: %s', country)
+
+        if calc_border_countries and len(self.border_countries) > 1:
+            log.info('+ Border countries will be processed')
 
     def filter_tags_from_country_osm_pbf_files(self):
         """
@@ -490,7 +498,7 @@ class OsmMaps:
 
         log.info('+ Split filtered country files to tiles: OK')
 
-    def merge_splitted_tiles_with_land_and_sea(self, calc_border_countries):
+    def merge_splitted_tiles_with_land_and_sea(self, process_border_countries):
         """
         Merge splitted tiles with land an sea
         """
@@ -519,7 +527,7 @@ class OsmMaps:
                     # loop through all countries of tile, if border-countries should be processed.
                     # if border-countries should not be processed, only process the "entered" country
                     for country in tile['countries']:
-                        if calc_border_countries or country in self.border_countries:
+                        if process_border_countries or country in self.border_countries:
                             cmd.append('--rbf')
                             cmd.append(os.path.join(
                                 out_tile_dir, f'split-{country}.osm.pbf'))
@@ -549,7 +557,7 @@ class OsmMaps:
                     # loop through all countries of tile, if border-countries should be processed.
                     # if border-countries should not be processed, only process the "entered" country
                     for country in tile['countries']:
-                        if calc_border_countries or country in self.border_countries:
+                        if process_border_countries or country in self.border_countries:
                             cmd.append(os.path.join(
                                 out_tile_dir, f'split-{country}.osm.pbf'))
                             cmd.append(os.path.join(

--- a/wahoo_map_creator.py
+++ b/wahoo_map_creator.py
@@ -33,7 +33,7 @@ oOSMmaps = OsmMaps(oInputData)
 # Read json file
 # Check for expired land polygons file and download, if too old
 # Check for expired .osm.pbf files and download, if too old
-oOSMmaps.process_input(oInputData.border_countries)
+oOSMmaps.process_input(oInputData.process_border_countries)
 oOSMmaps.check_and_download_files()
 
 
@@ -51,7 +51,8 @@ if oInputData.only_merge is False:
     oOSMmaps.split_filtered_country_files_to_tiles()
 
 # Merge splitted tiles with land an sea
-oOSMmaps.merge_splitted_tiles_with_land_and_sea(oInputData.border_countries)
+oOSMmaps.merge_splitted_tiles_with_land_and_sea(
+    oInputData.process_border_countries)
 
 # Creating .map files
 oOSMmaps.create_map_files(oInputData.save_cruiser, oInputData.tag_wahoo_xml)


### PR DESCRIPTION
## This PR…

- pre-selects the checkbox "process border countries" in the GUI
- changes the CLI argument `-bc` to `-nbc` - "no border countries". If it is provided, border countries will **not** be processed. If not providing, border countries will be processed.

## Considerations and implementations

This is a breaking-change because saved CLI calls, launch-configurations etc. need to be changed according to the above written.

## How to test

1. test via GUI
2. test via CLI with and without processing border countries

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
