### PR TITLE
[FEATURE] adjust BOLT device theme

### DIFF
--- a/device_themes/theme_adjusted/mapsforge-bolt.xml
+++ b/device_themes/theme_adjusted/mapsforge-bolt.xml
@@ -227,7 +227,7 @@
                 <rule e="way" k="highway" v="construction">
                     <line stroke="#000000" stroke-width="0"/>
                 </rule>
-                <rule e="way" k="highway" v="tertiary|tertiary_link|secondary_link|primary_link|trunk_link|motorway_link|secondary|primary|trunk" zoom-min="13">
+                <rule e="way" k="highway" v="tertiary|tertiary_link|secondary_link|primary_link|trunk_link|motorway_link|secondary|primary|trunk" zoom-min="10">
                     <line stroke="#FF0000" stroke-width="3.5"/>
                 </rule>
                 <rule e="way" k="highway" v="motorway" zoom-min="12" >
@@ -296,7 +296,7 @@
             <rule e="way" k="highway" v="unclassified|residential|living_street|road" zoom-min="15">
                 <line stroke="#FFFFFF" stroke-width="1"/>
             </rule>
-            <rule e="way" k="highway" v="tertiary|tertiary_link|secondary_link|primary_link|trunk_link|motorway_link|secondary|primary|trunk" zoom-min="13">
+            <rule e="way" k="highway" v="tertiary|tertiary_link|secondary_link|primary_link|trunk_link|motorway_link|secondary|primary|trunk" zoom-min="10">
                 <line stroke="#FFFFFF" stroke-width="2.5"/>
             </rule>
             <rule e="way" k="highway" v="trunk" zoom-max="12" zoom-min="11">

--- a/device_themes/theme_adjusted/mapsforge-bolt.xml
+++ b/device_themes/theme_adjusted/mapsforge-bolt.xml
@@ -182,7 +182,7 @@
     <rule cat="roads" e="way" k="tunnel" v="~|no|false" zoom-min="8">
         <rule e="way" k="area" v="~|no|false">
             <!-- highway casings -->
-            <rule e="way" k="highway" v="track|byway" zoom-min="13">
+            <rule e="way" k="highway" v="track|byway" zoom-min="14">
                 <!-- Solid. Usually a paved or heavily compacted hardcore surface. -->
                 <rule e="way" k="tracktype" v="grade1">
                     <line stroke="#000000" stroke-width="1.2" stroke-dasharray="8,4" stroke-linecap="butt"/>
@@ -218,7 +218,7 @@
                 <rule e="way" k="highway" v="service" zoom-min="15" zoom-max="15">
                     <line stroke="#000000" stroke-width="1.0"/>
                 </rule>
-                <rule e="way" k="highway" v="road|unclassified|residential|living_street" zoom-min="13" zoom-max="14">
+                <rule e="way" k="highway" v="road|unclassified|residential|living_street" zoom-min="14" zoom-max="14">
                     <line stroke="#000000" stroke-width="1.3"/>
                 </rule>
                 <rule e="way" k="highway" v="road|unclassified|residential|living_street" zoom-min="15">
@@ -258,7 +258,7 @@
             <rule e="way" k="highway" v="steps">
                 <line stroke="#000000" stroke-width="0.3" stroke-dasharray="3,3" stroke-linecap="butt"/>
             </rule>
-            <rule e="way" k="highway" v="track|byway" zoom-min="13">
+            <rule e="way" k="highway" v="track|byway" zoom-min="14">
                 <rule e="way" k="tracktype" v="grade1">
                     <line stroke="#FFFFFF" stroke-width="0.8"/>
                 </rule>
@@ -290,7 +290,7 @@
             <rule e="way" k="highway" v="construction">
                 <line stroke="#FFFFFF" stroke-width="1.3" stroke-dasharray="15,2" stroke-linecap="butt"/>
             </rule>
-            <rule e="way" k="highway" v="unclassified|residential|living_street|road" zoom-min="13" zoom-max="14">
+            <rule e="way" k="highway" v="unclassified|residential|living_street|road" zoom-min="14" zoom-max="14">
                 <line stroke="#FFFFFF" stroke-width="0.8"/>
             </rule>
             <rule e="way" k="highway" v="unclassified|residential|living_street|road" zoom-min="15">

--- a/docs/COPY_TO_WAHOO.md
+++ b/docs/COPY_TO_WAHOO.md
@@ -49,13 +49,16 @@ According to [the Wahoo documentation](https://support.wahoofitness.com/hc/en-us
 
 ## Copy device theme
 Device themes are described [here](TAGS_ON_MAP_AND_DEVICE.md#Device-Theme)
-A theme can be copied to your device like that:
-- ELEMNT/BOLT 
-  - copy "mapsforge-bolt.xml” of folder `common_resources/theme_adjusted` to `maps/mapsforge-bolt/mapsforge-bolt.xml` (just posted this in the google groups)
-- BOLTv2
-  - copy `assets/maps/vtm-elemnt/vtm-elemnt.xml` from the apk. Modify and copy the theme to `maps/vtm-elemnt/vtm-elemnt.xml`
-- ROAM
-  - copy `mapsforge-bolt.xml` of folder `common_resources/theme_adjusted` to `maps/mapsforge-roam/mapsforge-roam.xml`
+In this repo, device themes are stored in folder `device_themes`. There are initial versions and adjusted versions. Both can be further changed to your requirements!
+
+The following table shows the file per device and the location where the device theme needs to be copied to.
+
+| device | file                 | location                                 |
+| ------ | -------------------- | ---------------------------------------- |
+| BOLTv2 | `vtm-elemnt.xml`     | `maps/vtm-elemnt/vtm-elemnt.xml`         |
+| ROAM   | `mapsforge-roam.xml` | `maps/mapsforge-roam/mapsforge-roam.xml` |
+| BOLTv1 | `mapsforge-bolt.xml` | `maps/mapsforge-bolt/mapsforge-bolt.xml` |
+| ELEMNT | `mapsforge-bolt.xml` | `maps/mapsforge-bolt/mapsforge-bolt.xml` |
 
 # Delete temp-files and Clear Cache
 - delete all files from \ELEMNT-BOLT\USB storage\maps\temp\

--- a/docs/COPY_TO_WAHOO.md
+++ b/docs/COPY_TO_WAHOO.md
@@ -48,7 +48,6 @@ These tools can be helpful if you want to copy the files with a GUI and not via 
 According to [the Wahoo documentation](https://support.wahoofitness.com/hc/en-us/articles/115000127910-Connecting-ELEMNT-BOLT-ROAM-to-Desktop-or-Laptop-Computers) the device is able to connect via MTP. On windows you can navigate to the maps folder and drag new map files onto the folder called `maps\8`. The system will ask if you want to overwrite existing files. Don't forget to [delete temp-files and Clear Cache](#delete-temp-files-and-clear-cache). You can simply reboot to clear the cache.
 
 ## Copy device theme
-Device themes are described [here](TAGS_ON_MAP_AND_DEVICE.md#Device-Theme)
 In this repo, device themes are stored in folder `device_themes`. There are initial versions and adjusted versions. Both can be further changed to your requirements!
 
 The following table shows the file per device and the location where the device theme needs to be copied to.
@@ -59,6 +58,8 @@ The following table shows the file per device and the location where the device 
 | ROAM   | `mapsforge-roam.xml` | `maps/mapsforge-roam/mapsforge-roam.xml` |
 | BOLTv1 | `mapsforge-bolt.xml` | `maps/mapsforge-bolt/mapsforge-bolt.xml` |
 | ELEMNT | `mapsforge-bolt.xml` | `maps/mapsforge-bolt/mapsforge-bolt.xml` |
+
+Device themes are described [here](TAGS_ON_MAP_AND_DEVICE.md#Device-Theme)
 
 # Delete temp-files and Clear Cache
 - delete all files from \ELEMNT-BOLT\USB storage\maps\temp\

--- a/docs/TAGS_ON_MAP_AND_DEVICE.md
+++ b/docs/TAGS_ON_MAP_AND_DEVICE.md
@@ -48,7 +48,7 @@ There are two types of rendering methods: VTM and non-VTM rendering. This table 
 
 You can enable the VTM rendering method on Wahoo devices other than BOLTv2 by creating a empty file on the device with the name "cfg_BHomeActivity_VtmMaps" in the root folder.
 
-The theme is named `mapsforge-bolt.xml` or `mapsforge-roam.xml` for non-VTM rendering and `vtm-elemnt.xml` for VTM-rendering. It's content is more or less equal to the `tag-wahoo.xml` files.
+The device theme is named `mapsforge-bolt.xml` or `mapsforge-roam.xml` for non-VTM rendering and `vtm-elemnt.xml` for VTM-rendering. It's content is more or less equal to the `tag-wahoo.xml` files.
 
 ## Attribute "zoom-min"
 Each entry in the theme has a "zoom-min" attribute, which defines from which zoom level onwards the element will be shown. If zoom-min is set to 13, the OSM-tag will be displayed in zoom level 500m, 200m and 100m.

--- a/docs/TAGS_ON_MAP_AND_DEVICE.md
+++ b/docs/TAGS_ON_MAP_AND_DEVICE.md
@@ -34,9 +34,19 @@ E.g. roads, locations, ...
 Each entry has a "zoom-appear" attribute, which defines from which zoom level onwards the element will be stored in the map. If zoom-appear is set to 13, the OSM-tag will be stored in the 500m, 200m and 100m zoom levels and therefore could be rendered.
 
 # Device-Theme
-The theme defines, which OSM-tags are shown on the device or in cruiser where the theme should be used if you preview generated maps on your computer.
+The device theme defines, which OSM-tags are rendered on the device. In cruiser, you can also apply the device theme to preview generated maps on your computer.
 
-The theme is named `mapsforge-bolt.xml` or `mapsforge-roam.xml` and is content-wise equal to the `tag-wahoo.xml`
+There are two types of rendering methods: VTM and non-VTM rendering. This table shows the default rendering per device:
+| device | default rendering |
+| ------ | :---------------: |
+| BOLTv2 |        VTM        |
+| ROAM   |      non-VTM      |
+| BOLTv1 |      non-VTM      |
+| ELEMNT |      non-VTM      |
+
+You can enable the VTM rendering method on Wahoo devices other than BOLTv2 by creating a empty file on the device with the name "cfg_BHomeActivity_VtmMaps" in the root folder.
+
+The theme is named `mapsforge-bolt.xml` or `mapsforge-roam.xml` for non-VTM rendering and `vtm-elemnt.xml` for VTM-rendering. It's content is more or less equal to the `tag-wahoo.xml` files.
 
 ## Attribute "zoom-min"
 Each entry in the theme has a "zoom-min" attribute, which defines from which zoom level onwards the element will be shown. If zoom-min is set to 13, the OSM-tag will be displayed in zoom level 500m, 200m and 100m.

--- a/docs/TAGS_ON_MAP_AND_DEVICE.md
+++ b/docs/TAGS_ON_MAP_AND_DEVICE.md
@@ -9,6 +9,8 @@
   - [Copy the theme to the device](#copy-the-theme-to-the-device)
   - [Use the theme in cruiser](#use-the-theme-in-cruiser)
 - [Combination of tag-wahoo.xml and device-theme](#combination-of-tag-wahooxml-and-device-theme)
+- [Adjustments of the device themes](#adjustments-of-the-device-themes)
+  - [mapsforge-bolt.xml](#mapsforge-boltxml)
 
 
 # Zoom levels and scale
@@ -62,3 +64,15 @@ Because the theme kind of determines what you're gonna see, you want to preview 
 This zoom-appear in combination with the settings in the theme on the device (which can also be applied in cruiser) controls when certain elements are shown on our BOLT/ROAM etc (zoom-min).
 
 If a element is included in the map beginning from zoom level 10 (zoom-appear in tag-wahoo.xml) but on the device only displayed beginning with zoom level 12 (zoom-min in mapsforge-bolt.xml), the element is only displayed beginning zoom level 12.
+
+# Adjustments of the device themes
+This chapter documents, which changes are done to the files in `device_themes/adjusted` in comparision to the initial device themes.
+
+## mapsforge-bolt.xml
+- render highway-secondary when zoomed out
+  - from zoom 10 / 5km on (was zoom 13 / 500m before)
+  - to have a overview when zoomed "out"
+
+- render highway-road only when zoomed in
+  - from zoom 14 / 200m on (was zoom 13 / 500m before)
+  - to make it clearly arranged when zoomed "out" by zoom 500m


### PR DESCRIPTION
## This PR…

- maked changes to the BOLT device theme
- updates documentation concerning device themes

## Considerations and implementations

Roads are either rendered earlier or later to have a better overview when zoomed out or see less when zoomed in.

## How to test

1. use cruiser to view maps with the initial device theme in contrast to the adjusted device theme

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
