### PR TITLE
[FEAT] install: move work-directories to the user directory (prerequisite for PyPI setup)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -203,5 +203,21 @@
                 "-bc"
             ]
         },
+        {
+            "name": "malta only merge - user directory test",
+            "type": "python",
+            "request": "launch",
+            "module": "wahoo_mc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-co",
+                "malta",
+                "-c",
+                "-md",
+                "100",
+                "-om"
+            ]
+        }
     ]
 }

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -77,7 +77,7 @@ class TestDownloader(unittest.TestCase):
         """
         Test the download of geofabrik file via URL
         """
-        path = os.path.join(fd_fct.COMMON_DL_DIR, 'geofabrik.json')
+        path = os.path.join(fd_fct.USER_DL_DIR, 'geofabrik.json')
         download_file(
             path, 'https://download.geofabrik.de/index-v1.json', False)
 
@@ -90,7 +90,7 @@ class TestDownloader(unittest.TestCase):
 
         country = 'malta'
 
-        path = os.path.join(fd_fct.COMMON_DL_DIR, 'maps',
+        path = os.path.join(fd_fct.USER_DL_DIR, 'maps',
                             f'{country}' + '-latest.osm.pbf')
 
         if os.path.exists(path):
@@ -106,7 +106,7 @@ class TestDownloader(unittest.TestCase):
         Test if the removal of a not existing file raises a exception
         """
 
-        path = os.path.join(fd_fct.COMMON_DL_DIR, 'maps',
+        path = os.path.join(fd_fct.USER_DL_DIR, 'maps',
                             'malta' + '-latest.osm.pbf')
 
         if os.path.exists(path):

--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -26,7 +26,7 @@ def copy_static_maps_input_file(country, given_osm_pbf):
     given_osm_pbf_file = os.path.join(
         dirname_of_file, 'resources', given_osm_pbf)
     copy_to_path = os.path.join(
-        fd_fct.MAPS_DIR, country + '-latest.osm.pbf')
+        fd_fct.USER_MAPS_DIR, country + '-latest.osm.pbf')
 
     # copy file (new file takes creationdate as of now)
     shutil.copy2(given_osm_pbf_file, copy_to_path)

--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -236,7 +236,7 @@ class TestGeneratedFiles(unittest.TestCase):
                         given_output_file = os.path.join(
                             dirpath_2, file)
                         calculated_output_file = os.path.join(
-                            fd_fct.OUTPUT_DIR, dir_to_compare, directory, file)
+                            fd_fct.USER_OUTPUT_DIR, dir_to_compare, directory, file)
 
                         # is file equal?
                         self.assertTrue(filecmp.cmp(given_output_file, calculated_output_file,
@@ -248,7 +248,7 @@ class TestGeneratedFiles(unittest.TestCase):
                 given_output_file = os.path.join(
                     dirpath, file)
                 calculated_output_file = os.path.join(
-                    fd_fct.OUTPUT_DIR, dir_to_compare, file)
+                    fd_fct.USER_OUTPUT_DIR, dir_to_compare, file)
 
                 # is file equal?
                 self.assertTrue(filecmp.cmp(given_output_file, calculated_output_file,

--- a/tests/test_geofabrik.py
+++ b/tests/test_geofabrik.py
@@ -28,7 +28,7 @@ def calc_tiles_via_static_jsons(input_argument):
     calculate tiles using the json files in the repo
     the "old" way of doing
     """
-    json_file_path = os.path.join(fd_fct.COMMON_DIR, 'json',
+    json_file_path = os.path.join(fd_fct.RESOURCES_DIR, 'json',
                                   const_fct.get_region_of_country(input_argument), input_argument + '.json')
     tiles_via_static_json = fd_fct.read_json_file(json_file_path)
 

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -220,9 +220,9 @@ class TestStaticJsons(unittest.TestCase):
         use static json files in the repo to calculate relevant tile
         """
 
-        with open(os.path.join(fd_fct.COMMON_DIR, 'sea.osm')) as sea_file:  # pylint: disable=unspecified-encoding
+        with open(os.path.join(fd_fct.RESOURCES_DIR, 'sea.osm')) as sea_file:  # pylint: disable=unspecified-encoding
             sea_data_no_encoding = sea_file.read()
-        with open(os.path.join(fd_fct.COMMON_DIR, 'sea.osm'), encoding="utf-8") as sea_file:
+        with open(os.path.join(fd_fct.RESOURCES_DIR, 'sea.osm'), encoding="utf-8") as sea_file:
             sea_data_utf8 = sea_file.read()
 
         self.assertEqual(sea_data_no_encoding, sea_data_utf8)
@@ -285,7 +285,7 @@ class TestStaticJsons(unittest.TestCase):
         """
         json_file_path = const_fct.get_path_to_static_tile_json(country)
 
-        expected_path = os.path.join(fd_fct.COMMON_DIR, 'json',
+        expected_path = os.path.join(fd_fct.RESOURCES_DIR, 'json',
                                      exp_path + '.json')
 
         self.assertEqual(json_file_path, expected_path)
@@ -296,8 +296,8 @@ class TestStaticJsons(unittest.TestCase):
         go through all files in the common_resources/json directory
         - check if correct .json will be evaluated through get_path_to_static_tile_json function
         """
-        for folder in fd_fct.get_folders_in_folder(os.path.join(fd_fct.COMMON_DIR, 'json')):
-            for file in fd_fct.get_files_in_folder(os.path.join(fd_fct.COMMON_DIR, 'json', folder)):
+        for folder in fd_fct.get_folders_in_folder(os.path.join(fd_fct.RESOURCES_DIR, 'json')):
+            for file in fd_fct.get_files_in_folder(os.path.join(fd_fct.RESOURCES_DIR, 'json', folder)):
                 country = os.path.splitext(file)[0]
 
                 self.calculate_path_to_static_tile_json(

--- a/wahoo_mc/constants_functions.py
+++ b/wahoo_mc/constants_functions.py
@@ -125,7 +125,7 @@ def get_path_to_static_tile_json(country):
     """
     return the path to the static .json file with the files for the given country
     """
-    return os.path.join(fd_fct.COMMON_DIR, 'json',
+    return os.path.join(fd_fct.RESOURCES_DIR, 'json',
                         get_region_of_country(country), country + '.json')
 
 

--- a/wahoo_mc/downloader.py
+++ b/wahoo_mc/downloader.py
@@ -37,11 +37,11 @@ def download_file(target_filepath, url, is_zip):
     if is_zip:
         # build target-filepath based on last element of URL
         last_part = url.rsplit('/', 1)[-1]
-        dl_file_path = os.path.join(fd_fct.COMMON_DL_DIR, last_part)
+        dl_file_path = os.path.join(fd_fct.USER_DL_DIR, last_part)
         # download URL to file
         fd_fct.download_url_to_file(url, dl_file_path)
         # unpack it - should work on macOS and Windows
-        fd_fct.unzip(dl_file_path, fd_fct.COMMON_DL_DIR)
+        fd_fct.unzip(dl_file_path, fd_fct.USER_DL_DIR)
         # delete .zip file
         os.remove(dl_file_path)
     else:

--- a/wahoo_mc/downloader.py
+++ b/wahoo_mc/downloader.py
@@ -63,7 +63,7 @@ def get_osm_pbf_filepath_url(country):
     # get .osm.pbf region of country
     url = build_url_for_country_osm_pbf_download(country)
     map_file_path = os.path.join(
-        fd_fct.MAPS_DIR, f'{country}' + '-latest.osm.pbf')
+        fd_fct.USER_MAPS_DIR, f'{country}' + '-latest.osm.pbf')
     # return URL and download filepath
     return map_file_path, url
 
@@ -200,10 +200,10 @@ class Downloader:
 
             # check for already existing .osm.pbf file
             map_file_path = glob.glob(
-                f'{fd_fct.MAPS_DIR}/{transl_c}-latest.osm.pbf')
+                f'{fd_fct.USER_MAPS_DIR}/{transl_c}-latest.osm.pbf')
             if len(map_file_path) != 1:
                 map_file_path = glob.glob(
-                    f'{fd_fct.MAPS_DIR}/**/{transl_c}-latest.osm.pbf')
+                    f'{fd_fct.USER_MAPS_DIR}/**/{transl_c}-latest.osm.pbf')
 
             # delete .osm.pbf file if out of date
             if len(map_file_path) == 1 and os.path.isfile(map_file_path[0]):

--- a/wahoo_mc/file_directory_functions.py
+++ b/wahoo_mc/file_directory_functions.py
@@ -27,27 +27,21 @@ def get_git_root():
     return subprocess.Popen(['git', 'rev-parse', '--show-toplevel'],
                             stdout=subprocess.PIPE).communicate()[0].rstrip().decode('utf-8')
 
-# script_path = os.path.abspath(__file__) # i.e. /path/to/dir/foobar.py
-# alternatives for ROOT_DIR: #os.getcwd() #getGitRoot()
 
-
-# wahooMapsCreator directory
-WAHOO_MC_DIR = os.path.dirname(__file__)
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-
-WAHOO_MC_USER = os.path.join(str(Path.home()), 'wahooMapsCreator')
-
-# PAR_DIR = os.path.abspath(os.path.join(os.path.join(
-#     os.path.dirname(__file__), os.pardir), os.pardir))
-COMMON_DIR = os.path.join(WAHOO_MC_DIR, 'resources')
-USER_DL_DIR = os.path.join(WAHOO_MC_USER, '_download')
-USER_OUTPUT_DIR = os.path.join(WAHOO_MC_USER, '_tiles')
-MAPS_DIR = os.path.join(USER_DL_DIR, 'maps')
-TOOLING_DIR = os.path.join(ROOT_DIR, 'tooling')
-TOOLING_WIN_DIR = os.path.join(WAHOO_MC_DIR, 'tooling_win')
+# User
+USER_WAHOO_MC = os.path.join(str(Path.home()), 'wahooMapsCreator')
+USER_DL_DIR = os.path.join(USER_WAHOO_MC, '_download')
+USER_MAPS_DIR = os.path.join(USER_DL_DIR, 'maps')
 LAND_POLYGONS_PATH = os.path.join(
     USER_DL_DIR, 'land-polygons-split-4326', 'land_polygons.shp')
 GEOFABRIK_PATH = os.path.join(USER_DL_DIR, 'geofabrik.json')
+USER_OUTPUT_DIR = os.path.join(USER_WAHOO_MC, '_tiles')
+
+# Python Package - wahooMapsCreator directory
+WAHOO_MC_DIR = os.path.dirname(__file__)
+RESOURCES_DIR = os.path.join(WAHOO_MC_DIR, 'resources')
+TOOLING_WIN_DIR = os.path.join(WAHOO_MC_DIR, 'tooling_win')
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 
 def unzip(source_filename, dest_dir):
@@ -82,10 +76,10 @@ def initialize_work_directories():
 
     # USER_DIR = os.path.join(str(Path.home()), 'gitcommon')
 
-    os.makedirs(WAHOO_MC_USER, exist_ok=True)
+    os.makedirs(USER_WAHOO_MC, exist_ok=True)
 
     os.makedirs(USER_DL_DIR, exist_ok=True)
-    os.makedirs(MAPS_DIR, exist_ok=True)
+    os.makedirs(USER_MAPS_DIR, exist_ok=True)
     os.makedirs(USER_OUTPUT_DIR, exist_ok=True)
 
 

--- a/wahoo_mc/file_directory_functions.py
+++ b/wahoo_mc/file_directory_functions.py
@@ -29,7 +29,7 @@ def get_git_root():
 
 
 # User
-USER_WAHOO_MC = os.path.join(str(Path.home()), 'wahooMapsCreator')
+USER_WAHOO_MC = os.path.join(str(Path.home()), 'wahooMapsCreatorData')
 USER_DL_DIR = os.path.join(USER_WAHOO_MC, '_download')
 USER_MAPS_DIR = os.path.join(USER_DL_DIR, 'maps')
 LAND_POLYGONS_PATH = os.path.join(

--- a/wahoo_mc/file_directory_functions.py
+++ b/wahoo_mc/file_directory_functions.py
@@ -12,6 +12,8 @@ import sys
 import zipfile
 import logging
 from pathlib import Path
+from distutils.dir_util import copy_tree
+import shutil
 
 # import custom python packages
 import requests
@@ -86,6 +88,35 @@ def initialize_work_directories():
     os.makedirs(USER_DL_DIR, exist_ok=True)
     os.makedirs(MAPS_DIR, exist_ok=True)
     os.makedirs(USER_OUTPUT_DIR, exist_ok=True)
+
+
+def move_old_content_into_new_dirs():
+    """
+    copy files from download- and output- directory of earlier version to the new folders
+    delete directory from earlier versions afterwards
+
+    having folder on the same level as the wahooMapsCreator was introduces in release v1.1.0 with PR #93.
+    This coding is only valid/needed when using the cloned version or .zip version.
+    If working with a installed version via PyPI, nothing will be done because folders to copy do not exist
+    """
+    move_content('wahooMapsCreator_download', USER_DL_DIR)
+    move_content('wahooMapsCreator_output', USER_OUTPUT_DIR)
+
+
+def move_content(src_folder_name, dst):
+    """
+    copy files from source directory of to destination directory
+    delete source directory afterwards
+    """
+    # build path to old folder on the same level as wahooMapsCreator
+    par_dir = os.path.abspath(os.path.join(os.path.join(
+        os.path.dirname(__file__), os.pardir), os.pardir))
+    source_dir = os.path.join(par_dir, src_folder_name)
+
+    if os.path.exists(source_dir):
+        # copy & delete directory
+        copy_tree(source_dir, dst)
+        shutil.rmtree(source_dir)
 
 
 def create_empty_directories(tiles_from_json):

--- a/wahoo_mc/file_directory_functions.py
+++ b/wahoo_mc/file_directory_functions.py
@@ -111,6 +111,10 @@ def move_content(src_folder_name, dst_path):
         for item in os.listdir(source_dir):
             src = os.path.join(source_dir, item)
             dst = os.path.join(dst_path, item)
+            # next, if destination directory exists
+            if os.path.isdir(dst):
+                continue
+
             if os.path.isdir(src):
                 shutil.copytree(src, dst)
             else:

--- a/wahoo_mc/file_directory_functions.py
+++ b/wahoo_mc/file_directory_functions.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import zipfile
 import logging
+from pathlib import Path
 
 # import custom python packages
 import requests
@@ -32,17 +33,20 @@ def get_git_root():
 # wahooMapsCreator directory
 WAHOO_MC_DIR = os.path.dirname(__file__)
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-PAR_DIR = os.path.abspath(os.path.join(os.path.join(
-    os.path.dirname(__file__), os.pardir), os.pardir))
+
+WAHOO_MC_USER = os.path.join(str(Path.home()), 'wahooMapsCreator')
+
+# PAR_DIR = os.path.abspath(os.path.join(os.path.join(
+#     os.path.dirname(__file__), os.pardir), os.pardir))
 COMMON_DIR = os.path.join(WAHOO_MC_DIR, 'resources')
-COMMON_DL_DIR = os.path.join(PAR_DIR, 'wahooMapsCreator_download')
-OUTPUT_DIR = os.path.join(PAR_DIR, 'wahooMapsCreator_output')
-MAPS_DIR = os.path.join(COMMON_DL_DIR, 'maps')
+USER_DL_DIR = os.path.join(WAHOO_MC_USER, '_download')
+USER_OUTPUT_DIR = os.path.join(WAHOO_MC_USER, '_tiles')
+MAPS_DIR = os.path.join(USER_DL_DIR, 'maps')
 TOOLING_DIR = os.path.join(ROOT_DIR, 'tooling')
 TOOLING_WIN_DIR = os.path.join(WAHOO_MC_DIR, 'tooling_win')
 LAND_POLYGONS_PATH = os.path.join(
-    COMMON_DL_DIR, 'land-polygons-split-4326', 'land_polygons.shp')
-GEOFABRIK_PATH = os.path.join(COMMON_DL_DIR, 'geofabrik.json')
+    USER_DL_DIR, 'land-polygons-split-4326', 'land_polygons.shp')
+GEOFABRIK_PATH = os.path.join(USER_DL_DIR, 'geofabrik.json')
 
 
 def unzip(source_filename, dest_dir):
@@ -74,9 +78,14 @@ def initialize_work_directories():
     """
     Initialize work directories
     """
-    os.makedirs(COMMON_DL_DIR, exist_ok=True)
+
+    # USER_DIR = os.path.join(str(Path.home()), 'gitcommon')
+
+    os.makedirs(WAHOO_MC_USER, exist_ok=True)
+
+    os.makedirs(USER_DL_DIR, exist_ok=True)
     os.makedirs(MAPS_DIR, exist_ok=True)
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    os.makedirs(USER_OUTPUT_DIR, exist_ok=True)
 
 
 def create_empty_directories(tiles_from_json):
@@ -84,7 +93,7 @@ def create_empty_directories(tiles_from_json):
     create empty directory for the files
     """
     for tile in tiles_from_json:
-        outdir = os.path.join(OUTPUT_DIR, f'{tile["x"]}', f'{tile["y"]}')
+        outdir = os.path.join(USER_OUTPUT_DIR, f'{tile["x"]}', f'{tile["y"]}')
         if not os.path.isdir(outdir):
             os.makedirs(outdir)
 

--- a/wahoo_mc/file_directory_functions.py
+++ b/wahoo_mc/file_directory_functions.py
@@ -12,7 +12,6 @@ import sys
 import zipfile
 import logging
 from pathlib import Path
-from distutils.dir_util import copy_tree
 import shutil
 
 # import custom python packages
@@ -103,7 +102,7 @@ def move_old_content_into_new_dirs():
     move_content('wahooMapsCreator_output', USER_OUTPUT_DIR)
 
 
-def move_content(src_folder_name, dst):
+def move_content(src_folder_name, dst_path):
     """
     copy files from source directory of to destination directory
     delete source directory afterwards
@@ -115,7 +114,14 @@ def move_content(src_folder_name, dst):
 
     if os.path.exists(source_dir):
         # copy & delete directory
-        copy_tree(source_dir, dst)
+        for item in os.listdir(source_dir):
+            src = os.path.join(source_dir, item)
+            dst = os.path.join(dst_path, item)
+            if os.path.isdir(src):
+                shutil.copytree(src, dst)
+            else:
+                shutil.copy2(src, dst)
+
         shutil.rmtree(source_dir)
 
 

--- a/wahoo_mc/main.py
+++ b/wahoo_mc/main.py
@@ -9,6 +9,7 @@ import logging
 # import custom python packages
 from wahoo_mc.input import process_call_of_the_tool
 from wahoo_mc.file_directory_functions import initialize_work_directories
+from wahoo_mc.file_directory_functions import move_old_content_into_new_dirs
 from wahoo_mc.osm_maps_functions import OsmMaps
 
 # logging used in the terminal output:
@@ -31,6 +32,7 @@ def run():
     o_input_data.is_required_input_given_or_exit(issue_message=True)
 
     initialize_work_directories()
+    move_old_content_into_new_dirs()
 
     o_osm_maps = OsmMaps(o_input_data)
 

--- a/wahoo_mc/osm_maps_functions.py
+++ b/wahoo_mc/osm_maps_functions.py
@@ -53,7 +53,7 @@ def get_tile_by_one_xy_combination_from_jsons(xy_combination):
     get tile from json files by given X/Y coordinate combination
     """
     # go through all files in all folders of the "json" directory
-    file_path_jsons = os.path.join(fd_fct.COMMON_DIR, 'json')
+    file_path_jsons = os.path.join(fd_fct.RESOURCES_DIR, 'json')
 
     for folder in fd_fct.get_folders_in_folder(file_path_jsons):
         for file in fd_fct.get_filenames_of_jsons_in_folder(os.path.join(file_path_jsons, folder)):
@@ -376,12 +376,12 @@ class OsmMaps:
             if not os.path.isfile(out_file+'1.osm') or self.force_processing is True:
                 # Windows
                 if platform.system() == "Windows":
-                    cmd = ['python', os.path.join(fd_fct.COMMON_DIR,
+                    cmd = ['python', os.path.join(fd_fct.RESOURCES_DIR,
                                                   'shape2osm.py'), '-l', out_file, land_file]
 
                 # Non-Windows
                 else:
-                    cmd = ['python3', os.path.join(fd_fct.COMMON_DIR,
+                    cmd = ['python3', os.path.join(fd_fct.RESOURCES_DIR,
                                                    'shape2osm.py'), '-l', out_file, land_file]
 
                 run_subprocess_and_log_output(
@@ -405,7 +405,7 @@ class OsmMaps:
             if not os.path.isfile(out_file) or self.force_processing is True:
                 log.info(
                     '+ Generate sea %s of %s for Coordinates: %s,%s', tile_count, len(self.tiles), tile["x"], tile["y"])
-                with open(os.path.join(fd_fct.COMMON_DIR, 'sea.osm'), encoding="utf-8") as sea_file:
+                with open(os.path.join(fd_fct.RESOURCES_DIR, 'sea.osm'), encoding="utf-8") as sea_file:
                     sea_data = sea_file.read()
 
                     # Try to prevent getting outside of the +/-180 and +/- 90 degrees borders. Normally the +/- 0.1 are there to prevent white lines at tile borders
@@ -562,7 +562,7 @@ class OsmMaps:
                             ['--rx', 'file='+os.path.join(out_tile_dir, f'{land}'), '--s', '--m'])
                     cmd.extend(
                         ['--rx', 'file='+os.path.join(out_tile_dir, 'sea.osm'), '--s', '--m'])
-                    cmd.extend(['--tag-transform', 'file=' + os.path.join(fd_fct.COMMON_DIR,
+                    cmd.extend(['--tag-transform', 'file=' + os.path.join(fd_fct.RESOURCES_DIR,
                                                                           'tunnel-transform.xml'), '--wb', out_file, 'omitmetadata=true'])
 
                 # Non-Windows
@@ -662,7 +662,7 @@ class OsmMaps:
                 cmd.append('threads=' + threads)
                 # should work on macOS and Windows
                 cmd.append(
-                    f'tag-conf-file={os.path.join(fd_fct.COMMON_DIR, "tag_wahoo_adjusted", tag_wahoo_xml)}')
+                    f'tag-conf-file={os.path.join(fd_fct.RESOURCES_DIR, "tag_wahoo_adjusted", tag_wahoo_xml)}')
 
                 run_subprocess_and_log_output(
                     cmd, f'Error in Osmosis with country: c // tile: {tile["x"]},{tile["y"]}')
@@ -720,7 +720,7 @@ class OsmMaps:
             src = os.path.join(f'{fd_fct.USER_OUTPUT_DIR}',
                                f'{tile["x"]}', f'{tile["y"]}') + extension
             dst = os.path.join(
-                f'{fd_fct.WAHOO_MC_USER}', folder_name, f'{tile["x"]}', f'{tile["y"]}') + extension
+                f'{fd_fct.USER_WAHOO_MC}', folder_name, f'{tile["x"]}', f'{tile["y"]}') + extension
             self.copy_to_dst(extension, src, dst)
 
             if extension == '.map.lzma':
@@ -745,16 +745,16 @@ class OsmMaps:
                     [folder_name + '.zip', folder_name])
 
             run_subprocess_and_log_output(
-                cmd, f'! Error zipping map files for folder: {folder_name}', cwd=fd_fct.WAHOO_MC_USER)
+                cmd, f'! Error zipping map files for folder: {folder_name}', cwd=fd_fct.USER_WAHOO_MC)
 
             # Keep (True) or delete (False) the country/region map folders after compression
             if keep_map_folders is False:
                 try:
                     shutil.rmtree(os.path.join(
-                        f'{fd_fct.WAHOO_MC_USER}', folder_name))
+                        f'{fd_fct.USER_WAHOO_MC}', folder_name))
                 except OSError:
                     log.error(
-                        '! Error, could not delete folder %s', os.path.join(fd_fct.WAHOO_MC_USER, folder_name))
+                        '! Error, could not delete folder %s', os.path.join(fd_fct.USER_WAHOO_MC, folder_name))
 
             log.info('+ Zip %s files: OK', extension)
 

--- a/wahoo_mc/osm_maps_functions.py
+++ b/wahoo_mc/osm_maps_functions.py
@@ -721,14 +721,12 @@ class OsmMaps:
                                f'{tile["x"]}', f'{tile["y"]}') + extension
             dst = os.path.join(
                 f'{fd_fct.WAHOO_MC_USER}', folder_name, f'{tile["x"]}', f'{tile["y"]}') + extension
-            outdir = os.path.join(
-                f'{fd_fct.WAHOO_MC_USER}', folder_name, f'{tile["x"]}')
-            self.copy_to_dst(extension, src, dst, outdir)
+            self.copy_to_dst(extension, src, dst)
 
             if extension == '.map.lzma':
                 src = src + '.12'
                 dst = dst + '.12'
-                self.copy_to_dst(extension, src, dst, outdir)
+                self.copy_to_dst(extension, src, dst)
 
         if zip_folder:
             # Windows
@@ -762,12 +760,14 @@ class OsmMaps:
 
         log.info('+ Create %s files: OK', extension)
 
-    def copy_to_dst(self, extension, src, dst, outdir):
+    def copy_to_dst(self, extension, src, dst):
         """
         Zip .map or .map.lzma files
         postfix: '.map.lzma' for Wahoo tiles
         postfix: '.map' for Cruiser map files
         """
+        outdir = os.path.dirname(dst)
+
         # first create the to-directory if not already there
         os.makedirs(outdir, exist_ok=True)
 

--- a/wahoo_mc/osm_maps_functions.py
+++ b/wahoo_mc/osm_maps_functions.py
@@ -249,11 +249,11 @@ class OsmMaps:
         # Windows
         if platform.system() == "Windows":
             for key, val in self.border_countries.items():
-                out_file_o5m = os.path.join(fd_fct.OUTPUT_DIR,
+                out_file_o5m = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                             f'outFile-{key}.o5m')
-                out_file_o5m_filtered = os.path.join(fd_fct.OUTPUT_DIR,
+                out_file_o5m_filtered = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                                      f'outFileFiltered-{key}.o5m')
-                out_file_o5m_filtered_names = os.path.join(fd_fct.OUTPUT_DIR,
+                out_file_o5m_filtered_names = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                                            f'outFileFiltered-{key}-Names.o5m')
 
                 if not os.path.isfile(out_file_o5m_filtered) or self.force_processing is True:
@@ -302,9 +302,9 @@ class OsmMaps:
         # Non-Windows
         else:
             for key, val in self.border_countries.items():
-                out_file_o5m_filtered = os.path.join(fd_fct.OUTPUT_DIR,
+                out_file_o5m_filtered = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                                      f'filtered-{key}.o5m.pbf')
-                out_file_o5m_filtered_names = os.path.join(fd_fct.OUTPUT_DIR,
+                out_file_o5m_filtered_names = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                                            f'outFileFiltered-{key}-Names.o5m.pbf')
                 if not os.path.isfile(out_file_o5m_filtered) or self.force_processing is True:
                     log.info('+ Create filtered country file for %s', key)
@@ -345,9 +345,9 @@ class OsmMaps:
 
         tile_count = 1
         for tile in self.tiles:
-            land_file = os.path.join(fd_fct.OUTPUT_DIR,
+            land_file = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                      f'{tile["x"]}', f'{tile["y"]}', 'land.shp')
-            out_file = os.path.join(fd_fct.OUTPUT_DIR,
+            out_file = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                     f'{tile["x"]}', f'{tile["y"]}', 'land')
 
             # create land.dbf, land.prj, land.shp, land.shx
@@ -400,7 +400,7 @@ class OsmMaps:
 
         tile_count = 1
         for tile in self.tiles:
-            out_file = os.path.join(fd_fct.OUTPUT_DIR,
+            out_file = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                     f'{tile["x"]}', f'{tile["y"]}', 'sea.osm')
             if not os.path.isfile(out_file) or self.force_processing is True:
                 log.info(
@@ -449,11 +449,11 @@ class OsmMaps:
                     continue
                 log.info(
                     '+ Splitting tile %s of %s for Coordinates: %s,%s from map of %s', tile_count, len(self.tiles), tile["x"], tile["y"], country)
-                out_file = os.path.join(fd_fct.OUTPUT_DIR,
+                out_file = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}', f'split-{country}.osm.pbf')
-                out_file_names = os.path.join(fd_fct.OUTPUT_DIR,
+                out_file_names = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                               f'{tile["x"]}', f'{tile["y"]}', f'split-{country}-names.osm.pbf')
-                out_merged = os.path.join(fd_fct.OUTPUT_DIR,
+                out_merged = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                           f'{tile["x"]}', f'{tile["y"]}', 'merged.osm.pbf')
                 if not os.path.isfile(out_merged) or self.force_processing is True:
                     # Windows
@@ -524,7 +524,7 @@ class OsmMaps:
             log.info(
                 '+ Merging tiles for tile %s of %s for Coordinates: %s,%s', tile_count, len(self.tiles), tile["x"], tile["y"])
 
-            out_tile_dir = os.path.join(fd_fct.OUTPUT_DIR,
+            out_tile_dir = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}')
             out_file = os.path.join(out_tile_dir, 'merged.osm.pbf')
 
@@ -600,7 +600,7 @@ class OsmMaps:
         log.info('# Sorting land* osm files')
 
         # get all land* osm files
-        land_files = glob.glob(os.path.join(fd_fct.OUTPUT_DIR,
+        land_files = glob.glob(os.path.join(fd_fct.USER_OUTPUT_DIR,
                                             f'{tile["x"]}', f'{tile["y"]}', 'land*.osm'))
 
         # Windows
@@ -641,10 +641,10 @@ class OsmMaps:
         for tile in self.tiles:
             log.info(
                 '+ Creating map file for tile %s of %s for Coordinates: %s,%s', tile_count, len(self.tiles), tile["x"], tile["y"])
-            out_file = os.path.join(fd_fct.OUTPUT_DIR,
+            out_file = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                     f'{tile["x"]}', f'{tile["y"]}.map')
             if not os.path.isfile(out_file+'.lzma') or self.force_processing is True:
-                merged_file = os.path.join(fd_fct.OUTPUT_DIR,
+                merged_file = os.path.join(fd_fct.USER_OUTPUT_DIR,
                                            f'{tile["x"]}', f'{tile["y"]}', 'merged.osm.pbf')
 
                 # Windows
@@ -717,12 +717,12 @@ class OsmMaps:
         # copy the needed tiles to the country folder
         log.info('+ Copying %s tiles to output folders', extension)
         for tile in self.tiles:
-            src = os.path.join(f'{fd_fct.OUTPUT_DIR}',
+            src = os.path.join(f'{fd_fct.USER_OUTPUT_DIR}',
                                f'{tile["x"]}', f'{tile["y"]}') + extension
             dst = os.path.join(
-                f'{fd_fct.OUTPUT_DIR}', folder_name, f'{tile["x"]}', f'{tile["y"]}') + extension
+                f'{fd_fct.WAHOO_MC_USER}', folder_name, f'{tile["x"]}', f'{tile["y"]}') + extension
             outdir = os.path.join(
-                f'{fd_fct.OUTPUT_DIR}', folder_name, f'{tile["x"]}')
+                f'{fd_fct.WAHOO_MC_USER}', folder_name, f'{tile["x"]}')
             self.copy_to_dst(extension, src, dst, outdir)
 
             if extension == '.map.lzma':
@@ -747,16 +747,16 @@ class OsmMaps:
                     [folder_name + '.zip', folder_name])
 
             run_subprocess_and_log_output(
-                cmd, f'! Error zipping map files for folder: {folder_name}', cwd=fd_fct.OUTPUT_DIR)
+                cmd, f'! Error zipping map files for folder: {folder_name}', cwd=fd_fct.WAHOO_MC_USER)
 
             # Keep (True) or delete (False) the country/region map folders after compression
             if keep_map_folders is False:
                 try:
                     shutil.rmtree(os.path.join(
-                        f'{fd_fct.OUTPUT_DIR}', folder_name))
+                        f'{fd_fct.WAHOO_MC_USER}', folder_name))
                 except OSError:
                     log.error(
-                        '! Error, could not delete folder %s', os.path.join(fd_fct.OUTPUT_DIR, folder_name))
+                        '! Error, could not delete folder %s', os.path.join(fd_fct.WAHOO_MC_USER, folder_name))
 
             log.info('+ Zip %s files: OK', extension)
 


### PR DESCRIPTION
## This PR…

- moves the work-directories to the user level to implement PyPI setup later on and be still release independent

## Considerations and implementations

- `wahooMapsCreatorData` is the name of the folder 
  - generated maps are saved directly in `wahooMapsCreatorData` (was `output` before)
- `download` is renamed to `_download`
- `output` is renamed to `_tiles`

## How to test

1. process maps for a country or tile

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
