### PR TITLE
[FIX] Correctly include directory tooling_win in .zip and via PyPI package

### DIFF
--- a/conda_env/gdal-user.yml
+++ b/conda_env/gdal-user.yml
@@ -7,4 +7,4 @@ dependencies:
   - gdal=3.4.*
   - pip
   - pip:
-      - wahoomc==2.0.0
+      - wahoomc==2.0.1a1

--- a/conda_env/gdal-user.yml
+++ b/conda_env/gdal-user.yml
@@ -7,4 +7,4 @@ dependencies:
   - gdal=3.4.*
   - pip
   - pip:
-      - wahoomc==2.0.1a1
+      - wahoomc==2.0.1a4

--- a/copyFilesToDist.sh
+++ b/copyFilesToDist.sh
@@ -51,7 +51,7 @@ cd ..
 cp -R ${FOLDER_NAME_MAC}/* ${FOLDER_NAME_WIN}
 
 # add Win specific stuff
-cp -a ../wahoomc/tooling_win ./${FOLDER_NAME_WIN}/tooling_win
+cp -a ../wahoomc/tooling_win ./${FOLDER_NAME_WIN}/wahoomc/tooling_win
 
 # zip content into .zip file - by cd'ing without including root folder
 cd ${FOLDER_NAME_MAC}

--- a/copyFilesToDist.sh
+++ b/copyFilesToDist.sh
@@ -14,12 +14,12 @@ mkdir -p dist/${FOLDER_NAME_WIN}
 
 # zip cruiser stuff
 cd tooling/cruiser
-zip -r ../../dist/${FOLDER_NAME_CRUISER}.zip *
+zip -r -q ../../dist/${FOLDER_NAME_CRUISER}.zip *
 cd ../..
 
 # zip device themes
 cd device_themes
-zip -r ../dist/${FOLDER_NAME_DEVICE_THEMES}.zip *
+zip -r -q ../dist/${FOLDER_NAME_DEVICE_THEMES}.zip *
 cd ..
 
 # navigate into mac folder
@@ -55,8 +55,8 @@ cp -a ../wahoomc/tooling_win ./${FOLDER_NAME_WIN}/tooling_win
 
 # zip content into .zip file - by cd'ing without including root folder
 cd ${FOLDER_NAME_MAC}
-zip -r ../${FOLDER_NAME_MAC}.zip *
+zip -r -q ../${FOLDER_NAME_MAC}.zip *
 
 cd ..
 cd ${FOLDER_NAME_WIN}
-zip -r ../${FOLDER_NAME_WIN}.zip *
+zip -r -q ../${FOLDER_NAME_WIN}.zip *

--- a/docs/QUICKSTART_ANACONDA.md
+++ b/docs/QUICKSTART_ANACONDA.md
@@ -63,7 +63,7 @@ brew install osmosis
 1. Open terminal (macOS/Linux) or **Anaconda Prompt** (Windows, via Startmenu)
 2. Create a new Anaconda environment with needed packages
 ```
-conda create -n gdal-user python=3.7 geojson=2.5 gdal=3.4 pip --channel conda-forge
+conda create -n gdal-user python=3.7 geojson=2.5 gdal=3.4 pip --channel conda-forge --override-channels
 ```
 3. activate Anaconda environment with the command printed out (this needs to be done each time you want to use wahooMapsCreator maps)
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@ install_requires =
     shapely==1.8.*
 
 [options.package_data]
-wahoomc = resources/*.*, resources/**/*.*, resources/*/*/*.*, resources/*/*/*/*.*, tooling_win/*.*, tooling_win/**/*.*
+wahoomc = resources/*.*, resources/*/*.*, resources/*/*/*.*, resources/*/*/*/*.*, tooling_win/*.*, tooling_win/*/*.*, tooling_win/*/*/*.*, tooling_win/*/*/*/*.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@ install_requires =
     shapely==1.8.*
 
 [options.package_data]
-wahoomc = resources/*.*, resources/**/*.*, resources/*/*/*.*, resources/*/*/*/*.*
+wahoomc = resources/*.*, resources/**/*.*, resources/*/*/*.*, resources/*/*/*/*.*, tooling_win/*.*, tooling_win/**/*.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.0.0
+version = 2.0.1a1
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.0.1a1
+version = 2.0.1a4
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 


### PR DESCRIPTION
## This PR…

- closes #121
- includes `wahoomc/tooling_win` directory in the correct location in the .zip file for Windows
- includes `wahoomc/tooling_win`  in the python package distributed via PyPI

## Considerations and implementations

- setup.cfg to include via python build
- copyScript to include via .zip cration
- also enforces conda to use conda-forge channel

## How to test

1. ...
2. ...

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [ ] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
