### PR TITLE
[DEV] Refactor generated_files unittests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -141,43 +141,6 @@
             ]
         },
         {
-            "name": "test_2_malta",
-            "type": "python",
-            "request": "launch",
-            "module": "wahoomc",
-            "console": "integratedTerminal",
-            "args": [
-                "cli",
-                "-co",
-                "malta",
-                "-tag",
-                "tag-wahoo.xml",
-                "-fp",
-                "-c",
-                "-md",
-                "9999"
-            ]
-        },
-        {
-            "name": "test_2_liech",
-            "type": "python",
-            "request": "launch",
-            "module": "wahoomc",
-            "console": "integratedTerminal",
-            "args": [
-                "cli",
-                "-co",
-                "liechtenstein",
-                "-tag",
-                "tag-wahoo.xml",
-                "-fp",
-                "-c",
-                "-md",
-                "9999",
-                "-nbc"
-            ]
-        },
-        {
             "name": "x/y: 133/88 (germany&france)",
             "type": "python",
             "request": "launch",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ class TestCli(unittest.TestCase):
         tests, if help of top parser can be called
         """
 
-        result = os.system("python -h wahoomc -h")
+        result = os.system("python -m wahoomc -h")
 
         self.assertEqual(result, 0)
 
@@ -26,7 +26,7 @@ class TestCli(unittest.TestCase):
         tests, if CLI help can be called
         """
 
-        result = os.system("python -h wahoomc cli -h")
+        result = os.system("python -m wahoomc cli -h")
 
         self.assertEqual(result, 0)
 
@@ -35,7 +35,7 @@ class TestCli(unittest.TestCase):
         tests, if GUI help can be called
         """
 
-        result = os.system("python -h wahoomc gui -h")
+        result = os.system("python -m wahoomc gui -h")
 
         self.assertEqual(result, 0)
 

--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -22,7 +22,6 @@ def copy_static_maps_input_file(country, given_osm_pbf):
     """
     copy given file to download-directory
     """
-
     given_osm_pbf_file = os.path.join(
         dirname_of_file, 'resources', given_osm_pbf)
     copy_to_path = os.path.join(
@@ -36,7 +35,6 @@ def copy_static_land_polygon_input_folder(given_osm_pbf):
     """
     copy given folder to download-directory
     """
-
     # get parent folder of repo
     root_dir_parent = os.path.abspath(
         os.path.join(fd_fct.ROOT_DIR, os.pardir))
@@ -50,62 +48,6 @@ def copy_static_land_polygon_input_folder(given_osm_pbf):
         shutil.rmtree(copy_to_path)
     # copy folder (new file takes creationdate as of now)
     shutil.copytree(static_file_path, copy_to_path)
-
-
-def compare_test_resource_and_output(filename_to_compare):
-    """
-    compare if two files are equal.
-    """
-
-    given_output_file = os.path.join(
-        fd_fct.ROOT_DIR, 'tests/resources', filename_to_compare)
-
-    calculated_output_file = os.path.join(
-        fd_fct.ROOT_DIR, 'output', filename_to_compare)
-
-    # https://stackoverflow.com/questions/42512016/how-to-compare-two-files-as-part-of-unittest-while-getting-useful-output-in-cas
-    # filecmp.clear_cache()
-    files_are_equal = filecmp.cmp(given_output_file, calculated_output_file,
-                                  shallow=False)
-
-    # another possibility to compare files.
-    # if open(calculated_output_file, "rb").read() == open(
-    #         given_output_file, "rb").read():
-    #     files_are_equal = True
-
-    return files_are_equal
-
-
-def compare_dir_test_resource_and_output(dir_to_compare):
-    """
-    compare if two files are equal.
-    """
-
-    path_to_dir = os.path.join(
-        fd_fct.ROOT_DIR, 'tests/resources', dir_to_compare)
-
-    onlyfiles = [f for f in listdir(
-        path_to_dir) if isfile(join(path_to_dir, f))]
-
-    for file in onlyfiles:
-
-        given_output_file = os.path.join(
-            fd_fct.ROOT_DIR, 'tests/resources', dir_to_compare, file)
-
-        calculated_output_file = os.path.join(
-            fd_fct.ROOT_DIR, 'output', dir_to_compare, file)
-
-        # https://stackoverflow.com/questions/42512016/how-to-compare-two-files-as-part-of-unittest-while-getting-useful-output-in-cas
-        # filecmp.clear_cache()
-        files_are_equal = filecmp.cmp(given_output_file, calculated_output_file,
-                                      shallow=False)
-
-        # another possibility to compare files.
-        # if open(calculated_output_file, "rb").read() == open(
-        #         given_output_file, "rb").read():
-        #     files_are_equal = True
-
-        return files_are_equal
 
 
 class TestGeneratedFiles(unittest.TestCase):
@@ -126,20 +68,18 @@ class TestGeneratedFiles(unittest.TestCase):
         copy_static_land_polygon_input_folder(
             'land-polygons-split-4326_2021-10-31')
 
-        # self.copy_static_maps_input_file(
-        #     'malta', 'malta-latest_2021-10-31.osm.pbf')
-        # self.copy_static_maps_input_file(
-        #     'liechtenstein', 'liechtenstein-latest_2021-10-31.osm.pbf')
+        copy_static_maps_input_file(
+            'malta', 'malta-latest_2021-10-31.osm.pbf')
+        copy_static_maps_input_file(
+            'liechtenstein', 'liechtenstein-latest_2021-10-31.osm.pbf')
 
     def test_calc_output_malta_and_compare(self):
         """
         Test output of countries without border countries
         - of malta
         """
-
-        # run tool for countries
-        self.run_wahoomapscreator_cli(
-            'malta', 'malta-latest_2021-10-31.osm.pbf')
+        # run tool for country
+        self.run_wahoomapscreator_cli('malta')
 
         # compare generated given merged.osm.pbf-file with reference-file
         self.compare_dir_sub_test_resource_and_output(
@@ -150,22 +90,18 @@ class TestGeneratedFiles(unittest.TestCase):
         Test output of countries without border countries
         - of liechtenstein
         """
-
         # run tool for country
-        self.run_wahoomapscreator_cli(
-            'liechtenstein', 'liechtenstein-latest_2021-10-31.osm.pbf')
+        self.run_wahoomapscreator_cli('liechtenstein')
 
         # compare generated given merged.osm.pbf-file with reference-file
         self.compare_dir_sub_test_resource_and_output(
             os.path.join('134', '89'))
 
-    def run_wahoomapscreator_cli(self, country, given_osm_pbf):
+    def run_wahoomapscreator_cli(self, country):
         """
         runs wahooMapsCreator for given country and static osm.pbf file via CLI
         - without border countries
         """
-        copy_static_maps_input_file(country, given_osm_pbf)
-
         # run processing of input-country via CLI
         result = os.system(
             f'python -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc')

--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -4,9 +4,7 @@ tests the generated files of a full-run of the tool against fixed files
 
 import filecmp
 import os
-from os import listdir
 from os import walk
-from os.path import isfile, join
 import platform
 import shutil
 import unittest

--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -122,94 +122,53 @@ class TestGeneratedFiles(unittest.TestCase):
     - 100.map.lzma
     """
 
-    # def setUp(self):
-    #     self.copy_static_land_polygon_input_folder(
-    #         'land-polygons-split-4326_2021-10-31')
-
-    #     self.copy_static_maps_input_file(
-    #         'malta', 'malta-latest_2021-10-31.osm.pbf')
-    #     self.copy_static_maps_input_file(
-    #         'liechtenstein', 'liechtenstein-latest_2021-10-31.osm.pbf')
-
-    def test_1_setup(self):  # pylint: disable=no-self-use
-        """
-        Copy defined static land-polygons and .osm.pbf files.
-        The files are used in the launch.json configs "test_2_malta" and "test_2_liech"
-        """
-
+    def setUp(self):
         copy_static_land_polygon_input_folder(
             'land-polygons-split-4326_2021-10-31')
 
-        copy_static_maps_input_file(
-            'malta', 'malta-latest_2021-10-31.osm.pbf')
-        copy_static_maps_input_file(
-            'liechtenstein', 'liechtenstein-latest_2021-10-31.osm.pbf')
+        # self.copy_static_maps_input_file(
+        #     'malta', 'malta-latest_2021-10-31.osm.pbf')
+        # self.copy_static_maps_input_file(
+        #     'liechtenstein', 'liechtenstein-latest_2021-10-31.osm.pbf')
 
-    def test_3_malta_compare_output(self):
+    def test_calc_output_malta_and_compare(self):
         """
-        Compare output of countries without border countries
+        Test output of countries without border countries
         - of malta
         """
+
+        # run tool for countries
+        self.run_wahoomapscreator_cli(
+            'malta', 'malta-latest_2021-10-31.osm.pbf')
 
         # compare generated given merged.osm.pbf-file with reference-file
         self.compare_dir_sub_test_resource_and_output(
             os.path.join('138', '100'))
 
-    def test_3_liech_compare_output(self):
+    def test_calc_output_liechtenstein_and_compare(self):
         """
-        Compare output of countries without border countries
+        Test output of countries without border countries
         - of liechtenstein
         """
+
+        # run tool for country
+        self.run_wahoomapscreator_cli(
+            'liechtenstein', 'liechtenstein-latest_2021-10-31.osm.pbf')
 
         # compare generated given merged.osm.pbf-file with reference-file
         self.compare_dir_sub_test_resource_and_output(
             os.path.join('134', '89'))
 
-    # def test_calc_output_malta(self):
-    #     """
-    #     Test output of countries without border countries
-    #     - of malta
-    #     """
-
-    #     # run tool for countries
-    #     self.run_wahoomapscreator_cli(
-    #         'malta', 'malta-latest_2021-10-31.osm.pbf')
-
-    #     # compare generated given merged.osm.pbf-file with reference-file
-    #     # equals_merged = self.compare_test_resource_and_output(
-    #     #     '138/100/merged.osm.pbf')
-    #     self.compare_dir_sub_test_resource_and_output(
-    #         os.path.join('138', '100'))
-
-    # def test_calc_output_liechtenstein(self):
-    #     """
-    #     Test output of countries without border countries
-    #     - of liechtenstein
-    #     """
-
-    #     # run tool for country
-    #     self.run_wahoomapscreator_cli(
-    #         'liechtenstein', 'liechtenstein-latest_2021-10-31.osm.pbf')
-
-    #     # compare generated given merged.osm.pbf-file with reference-file
-
-    #     self.compare_dir_sub_test_resource_and_output(
-    #         os.path.join('134', '89'))
-
     def run_wahoomapscreator_cli(self, country, given_osm_pbf):
         """
         runs wahooMapsCreator for given country and static osm.pbf file via CLI
+        - without border countries
         """
         copy_static_maps_input_file(country, given_osm_pbf)
 
         # run processing of input-country via CLI
-        if platform.system() == "Windows":
-            cli_command = "python"
-        else:
-            cli_command = "python3"
-
         result = os.system(
-            f'{cli_command} -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 100')
+            f'python -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc')
 
         # check if run was successful
         self.assertEqual(result, 0)


### PR DESCRIPTION
## This PR…

- refactor generated-maps unittests

## Considerations and implementations

- move processing from launch.json to unittest
- correctly use setUp function
- no clicking around needed anymore
- all unittests can be run in one run now

## How to test

1. run all unittests
2. run generated-maps unittests

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
