### PR TITLE
[FEAT] Use `python` instead of `python3` to call `shape2osm.py` to be macOS Monterey/M1 compatible

### DIFF
--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -385,8 +385,8 @@ class OsmMaps:
 
                 # Non-Windows
                 else:
-                    cmd = ['python3', os.path.join(RESOURCES_DIR,
-                                                   'shape2osm.py'), '-l', out_file, land_file]
+                    cmd = ['python', os.path.join(RESOURCES_DIR,
+                                                  'shape2osm.py'), '-l', out_file, land_file]
 
                 run_subprocess_and_log_output(
                     cmd, f'! Error creating land.osm for tile: {tile["x"]},{tile["y"]}')


### PR DESCRIPTION
## This PR…

- changes the call of shape2osm.py from `python3` call to `python`
- there might be another way to get around this situation on the computer. Because python3 is already changed everywhere in the repo beside this one line, this is a logical step 

## Considerations and implementations
the error can be produced with a rather fresh macOS Monterey 12.4 on MBP M1 with: `python -m wahoomc cli -co malta -md 100 -fp`
and run via debugging this is the error:
![grafik](https://user-images.githubusercontent.com/53038537/171986416-18daabbd-eb63-4d71-970e-b6623864a8a9.png)

this is the cause:
![grafik](https://user-images.githubusercontent.com/53038537/171986467-1bbe600c-e99e-49aa-a3e1-ce03c8b821fa.png)

## How to test

1. Run `python -m wahoomc cli -co malta -md 100 -fp`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
