### PR TITLE
[FIX] Use `latin-1` encoding as fallback if UnicodeDecodeError with `utf-8`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.0.1
+version = 2.0.2a1
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.0.2a1
+version = 2.0.2a3
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -23,7 +23,8 @@ def run():
     main program run
     """
     # create logger
-    logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+    logging.basicConfig(format='%(levelname)s:%(message)s',
+                        level=logging.DEBUG)
 
     # handle GUI and CLI processing via one function and different cli-calls
     o_input_data = process_call_of_the_tool()

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -78,7 +78,7 @@ def run_subprocess_and_log_output(cmd, error_message, cwd=""):
     if not cwd:
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as process:
             for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines
-                log.debug('subprocess:%r', line.decode("utf-8").strip())
+                log.debug('subprocess:%r', line.decode("latin-1").strip())
     else:
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd) as process:
             for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -78,11 +78,17 @@ def run_subprocess_and_log_output(cmd, error_message, cwd=""):
     if not cwd:
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as process:
             for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines
-                log.debug('subprocess:%r', line.decode("latin-1").strip())
+                try:
+                    log.debug('subprocess:%r', line.decode("utf-8").strip())
+                except UnicodeDecodeError:
+                    log.debug('subprocess:%r', line.decode("latin-1").strip())
     else:
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd) as process:
             for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines
-                log.debug('subprocess:%r', line.decode("utf-8").strip())
+                try:
+                    log.debug('subprocess:%r', line.decode("utf-8").strip())
+                except UnicodeDecodeError:
+                    log.debug('subprocess:%r', line.decode("latin-1").strip())
 
     if error_message and process.wait() != 0:  # 0 means success
         log.error(error_message)


### PR DESCRIPTION
## This PR…

- closes #132 
- uses encoding `latin-1` if there is a UnicodeDecodeError with `utf-8`

## Considerations and implementations

The sourc of this error might be the encoding or language setting of the Win10 computer.

## How to test

see #132 

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [x] Tested with Windows
