### PR TITLE
[FIX] handle USA json country names via conversion of `_` to `-`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -217,6 +217,21 @@
                 "100",
                 "-om"
             ]
+        },
+        {
+            "name": "american_samoa #135",
+            "type": "python",
+            "request": "launch",
+            "module": "wahoomc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-co",
+                "american_samoa",
+                "-c",
+                "-md",
+                "100",
+            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -232,6 +232,21 @@
                 "-md",
                 "100",
             ]
+        },
+        {
+            "name": "commonwealth_of_the_northern_mariana_islands #135",
+            "type": "python",
+            "request": "launch",
+            "module": "wahoomc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-co",
+                "commonwealth_of_the_northern_mariana_islands",
+                "-c",
+                "-md",
+                "100",
+            ]
         }
     ]
 }

--- a/wahoomc/constants.py
+++ b/wahoomc/constants.py
@@ -75,7 +75,21 @@ Translate_Country = {
     'western_sahara':                   'morocco',
     'qatar':                            'gcc-states',
     'åland':                            'finland',
-    'new_mexico':                       'new-mexico'
+    'new_mexico':                       'new-mexico',
+    'american_samoa':                   'samoa',
+    'commonwealth_of_the_northern_mariana_islands':                   'american-oceania',
+    'northern_mariana_islands':         'american-oceania',
+    'new_york':                         'new-york',
+    'new_hampshire':                    'new-hampshire',
+    'new_jersey':                       'new-jersey',
+    'rhode_island':                     'rhode-island',
+    'district_of_columbia':             'district-of-columbia',
+    'north_carolina':                   'north-carolina',
+    'south_carolina':                   'south-carolina',
+    'north_dakota':                     'north-dakota',
+    'south_dakota':                     'south-dakota',
+    'west_virginia':                    'west-virginia',
+    'new_hampshire':                    'new-hampshire'
 }
 
 continents = ['europe', 'unitedstates', 'north-america', 'south-america', 'asia', 'oceania',
@@ -166,7 +180,7 @@ asia_geofabrik = ['afghanistan', 'armenia', 'azerbaijan', 'bangladesh', 'bhutan'
                   'pakistan', 'philippines', 'russian federation', 'south-korea', 'sri-lanka', 'syria',
                   'taiwan', 'tajikistan', 'thailand', 'turkmenistan', 'uzbekistan', 'vietnam', 'yemen']
 
-australiaoceania_geofabrik = ['american oceania', 'australia', 'cook islands', 'fiji',
+australiaoceania_geofabrik = ['american-oceania', 'australia', 'cook islands', 'fiji',
                               'île de clipperton', 'kiribati', 'marshall islands', 'micronesia', 'nauru',
                               'new caledonia', 'new zealand', 'niue', 'palau', 'papua new guinea',
                               'pitcairn islands', 'polynesie-francaise', 'samoa', 'solomon islands', 'tokelau',

--- a/wahoomc/constants.py
+++ b/wahoomc/constants.py
@@ -88,8 +88,7 @@ Translate_Country = {
     'south_carolina':                   'south-carolina',
     'north_dakota':                     'north-dakota',
     'south_dakota':                     'south-dakota',
-    'west_virginia':                    'west-virginia',
-    'new_hampshire':                    'new-hampshire'
+    'west_virginia':                    'west-virginia'
 }
 
 continents = ['europe', 'unitedstates', 'north-america', 'south-america', 'asia', 'oceania',

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -64,21 +64,9 @@ def download_file(target_filepath, url, is_zip):
 
 def get_osm_pbf_filepath_url(country):
     """
-    evaluate a countries' OSM file URL and download filepath
+    build the geofabrik download url to a countries' OSM file and download filepath
     """
 
-    # get .osm.pbf region of country
-    url = build_url_for_country_osm_pbf_download(country)
-    map_file_path = os.path.join(
-        USER_MAPS_DIR, f'{country}' + '-latest.osm.pbf')
-    # return URL and download filepath
-    return map_file_path, url
-
-
-def build_url_for_country_osm_pbf_download(country):
-    """
-    build the geofabrik download url to a countries' OSM file
-    """
     transl_c = const_fct.translate_country_input_to_geofabrik(country)
     region = const_fct.get_geofabrik_region_of_country(country)
     if region != 'no':
@@ -86,7 +74,12 @@ def build_url_for_country_osm_pbf_download(country):
             '/' + transl_c + '-latest.osm.pbf'
     else:
         url = 'https://download.geofabrik.de/' + transl_c + '-latest.osm.pbf'
-    return url
+
+    map_file_path = os.path.join(
+        USER_MAPS_DIR, f'{transl_c}' + '-latest.osm.pbf')
+
+    # return URL and download filepath
+    return map_file_path, url
 
 
 class Downloader:


### PR DESCRIPTION
## This PR…

- replaces `_` by `-` in relevant json files for USA
- another possibility than #135

## Considerations and implementations

this change is done in favor of #135 because fever files are changed and there is a existing functionality for country to geofabrik country mapping.

## How to test

1. `python -m wahoomc cli -co commonwealth_of_the_northern_mariana_islands`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
