### PR TITLE
[BREAKING] Remove argument `-km` (keep_map_folders)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,6 +85,39 @@
             ]
         },
         {
+            "name": "malta -c",
+            "type": "python",
+            "request": "launch",
+            "module": "wahoomc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-co",
+                "malta",
+                "-fp",
+                "-c",
+                "-md",
+                "100"
+            ]
+        },
+        {
+            "name": "malta -c -km",
+            "type": "python",
+            "request": "launch",
+            "module": "wahoomc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-co",
+                "malta",
+                "-fp",
+                "-c",
+                "-md",
+                "100",
+                "-km"
+            ]
+        },
+        {
             "name": "malta-poi",
             "type": "python",
             "request": "launch",
@@ -153,7 +186,7 @@
             ]
         },
         {
-            "name": "x/y: 138/100 (malta)",
+            "name": "x/y: 138/100 (malta) -c",
             "type": "python",
             "request": "launch",
             "module": "wahoomc",
@@ -161,7 +194,28 @@
             "args": [
                 "cli",
                 "-xy",
-                "138/100"
+                "138/100",
+                "-fp",
+                "-c",
+                "-md",
+                "100"
+            ]
+        },
+        {
+            "name": "x/y: 138/100 (malta) -c -km",
+            "type": "python",
+            "request": "launch",
+            "module": "wahoomc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-xy",
+                "138/100",
+                "-fp",
+                "-c",
+                "-md",
+                "100",
+                "-km"
             ]
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -101,23 +101,6 @@
             ]
         },
         {
-            "name": "malta -c -km",
-            "type": "python",
-            "request": "launch",
-            "module": "wahoomc",
-            "console": "integratedTerminal",
-            "args": [
-                "cli",
-                "-co",
-                "malta",
-                "-fp",
-                "-c",
-                "-md",
-                "100",
-                "-km"
-            ]
-        },
-        {
             "name": "malta-poi",
             "type": "python",
             "request": "launch",
@@ -199,23 +182,6 @@
                 "-c",
                 "-md",
                 "100"
-            ]
-        },
-        {
-            "name": "x/y: 138/100 (malta) -c -km",
-            "type": "python",
-            "request": "launch",
-            "module": "wahoomc",
-            "console": "integratedTerminal",
-            "args": [
-                "cli",
-                "-xy",
-                "138/100",
-                "-fp",
-                "-c",
-                "-md",
-                "100",
-                "-km"
             ]
         },
         {

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -82,9 +82,6 @@ def process_call_of_the_tool():
     # zip the country (and country-maps) folder
     options_args.add_argument('-z', '--zip', action='store_true',
                               help="zip the country (and country-maps) folder")
-    # option to keep the /output/country/ and /output/country-maps folders in the output
-    options_args.add_argument('-km', '--keep_map_folders', action='store_true',
-                              help="keep the country and country-maps folders in the output")
 
     args = parser_top.parse_args()
 
@@ -111,7 +108,6 @@ def process_call_of_the_tool():
 
     o_input_data.tag_wahoo_xml = args.tag_wahoo_xml
     o_input_data.only_merge = args.only_merge
-    o_input_data.keep_map_folders = args.keep_map_folders
     o_input_data.save_cruiser = args.cruiser
     o_input_data.zip_folder = args.zip
 
@@ -154,10 +150,6 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
         self.only_merge = False
 
         self.tag_wahoo_xml = "tag-wahoo.xml"
-        # Folder /output/country and /output/country-maps map folders
-        # True - Keep them after compression
-        # False - Delete them after compression
-        self.keep_map_folders = False
 
         # Way of calculating the relevant tiles for given input (country)
         # True - Use geofabrik index-v1.json file
@@ -267,7 +259,6 @@ class GuiInput(tk.Tk):
         self.o_input_data.only_merge = tab2.first.checkb_only_merge_val.get()
         self.o_input_data.save_cruiser = tab2.first.checkb_save_cruiser_val.get()
         self.o_input_data.zip_folder = tab2.first.checkb_zip_folder_val.get()
-        self.o_input_data.keep_map_folders = tab2.first.checkb_keep_map_folders_val.get()
 
         # get text without \n in the end
         self.o_input_data.tag_wahoo_xml = tab2.second.input_tag_wahoo_xml.get()
@@ -421,5 +412,3 @@ class CheckbuttonsTab2(tk.Frame):
                                                        "Save uncompressed maps for Cruiser", 2)
         self.checkb_zip_folder_val = create_checkbox(self, oInputData.zip_folder,
                                                      "Zip folder with generated files", 3)
-        self.checkb_keep_map_folders_val = create_checkbox(self, oInputData.keep_map_folders,
-                                                           "Keep the country and country-maps folders in the output", 1)

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -76,15 +76,15 @@ def process_call_of_the_tool():
     # only merge - used for special usecases
     options_args.add_argument('-om', '--only_merge', action='store_true',
                               help="only merge, do no other processing")
-    # option to keep the /output/country/ and /output/country-maps folders in the output
-    options_args.add_argument('-km', '--keep_map_folders', action='store_true',
-                              help="keep the country and country-maps folders in the output")
     # option to calculate tiles to process based on Geofabrik index-v1.json file
     options_args.add_argument('-gt', '--geofabrik_tiles', action='store_true',
                               help="calculate tiles based on geofabrik index-v1.json file")
     # zip the country (and country-maps) folder
     options_args.add_argument('-z', '--zip', action='store_true',
                               help="zip the country (and country-maps) folder")
+    # option to keep the /output/country/ and /output/country-maps folders in the output
+    options_args.add_argument('-km', '--keep_map_folders', action='store_true',
+                              help="keep the country and country-maps folders in the output")
 
     args = parser_top.parse_args()
 
@@ -265,9 +265,9 @@ class GuiInput(tk.Tk):
         self.o_input_data.geofabrik_tiles = tab1.third.checkb_geofabrik_tiles_val.get()
 
         self.o_input_data.only_merge = tab2.first.checkb_only_merge_val.get()
-        self.o_input_data.keep_map_folders = tab2.first.checkb_keep_map_folders_val.get()
         self.o_input_data.save_cruiser = tab2.first.checkb_save_cruiser_val.get()
         self.o_input_data.zip_folder = tab2.first.checkb_zip_folder_val.get()
+        self.o_input_data.keep_map_folders = tab2.first.checkb_keep_map_folders_val.get()
 
         # get text without \n in the end
         self.o_input_data.tag_wahoo_xml = tab2.second.input_tag_wahoo_xml.get()
@@ -417,9 +417,9 @@ class CheckbuttonsTab2(tk.Frame):
 
         self.checkb_only_merge_val = create_checkbox(self, oInputData.only_merge,
                                                      "Only merge, do no other processing", 0)
-        self.checkb_keep_map_folders_val = create_checkbox(self, oInputData.keep_map_folders,
-                                                           "Keep the country and country-maps folders in the output", 1)
         self.checkb_save_cruiser_val = create_checkbox(self, oInputData.save_cruiser,
                                                        "Save uncompressed maps for Cruiser", 2)
         self.checkb_zip_folder_val = create_checkbox(self, oInputData.zip_folder,
                                                      "Zip folder with generated files", 3)
+        self.checkb_keep_map_folders_val = create_checkbox(self, oInputData.keep_map_folders,
+                                                           "Keep the country and country-maps folders in the output", 1)

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -65,10 +65,8 @@ def run():
                                 o_input_data.tag_wahoo_xml)
 
     # Zip .map.lzma files
-    o_osm_maps.make_and_zip_files(
-        o_input_data.keep_map_folders, '.map.lzma', o_input_data.zip_folder)
+    o_osm_maps.make_and_zip_files('.map.lzma', o_input_data.zip_folder)
 
     # Make Cruiser map files zip file
     if o_input_data.save_cruiser is True:
-        o_osm_maps.make_and_zip_files(
-            o_input_data.keep_map_folders, '.map', o_input_data.zip_folder)
+        o_osm_maps.make_and_zip_files('.map', o_input_data.zip_folder)

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -701,7 +701,7 @@ class OsmMaps:
 
         log.info('+ Creating .map files: OK')
 
-    def make_and_zip_files(self, keep_map_folders, extension, zip_folder):
+    def make_and_zip_files(self, extension, zip_folder):
         """
         make or make and zip .map or .map.lzma files
         extension: '.map.lzma' for Wahoo tiles
@@ -756,14 +756,13 @@ class OsmMaps:
             run_subprocess_and_log_output(
                 cmd, f'! Error zipping map files for folder: {folder_name}', cwd=USER_WAHOO_MC)
 
-            # Keep (True) or delete (False) the country/region map folders after compression
-            if keep_map_folders is False:
-                try:
-                    shutil.rmtree(os.path.join(
-                        f'{USER_WAHOO_MC}', folder_name))
-                except OSError:
-                    log.error(
-                        '! Error, could not delete folder %s', os.path.join(USER_WAHOO_MC, folder_name))
+            # Delete the country/region map folders after compression
+            try:
+                shutil.rmtree(os.path.join(
+                    f'{USER_WAHOO_MC}', folder_name))
+            except OSError:
+                log.error(
+                    '! Error, could not delete folder %s', os.path.join(USER_WAHOO_MC, folder_name))
 
             log.info('+ Zip %s files: OK', extension)
 


### PR DESCRIPTION
## This PR…

- Removes the argument `-km`, keep_map_folders from GUI and CLI input as well as processing in the python files

## Considerations and implementations

- The argument was not easy to understand in coding
- And might only be used by a few people
- legacy coding of the time where the default was compressing the output country-folders. Ssince #118, compressing is no longer default but possible with argument `-z`

## How to test

1. Create maps of a country without further options
2. Create maps of a country with -z argument

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
