### PR TITLE
[FEAT] Refactor getting tag-wahoo xml file, distinguish Osmosis errors, reset default logging level to INFO

### DIFF
--- a/tests/test_file_directory.py
+++ b/tests/test_file_directory.py
@@ -1,0 +1,36 @@
+"""
+tests for file directory functions file
+"""
+import os
+import unittest
+
+from wahoomc import file_directory_functions as fd_fct
+from wahoomc.file_directory_functions import TagWahooXmlNotFoundError
+from wahoomc import constants
+
+
+class TestFileDirectory(unittest.TestCase):
+    """
+    tests for file directory functions
+    """
+
+    def test_not_existing_tag_wahoo_xml(self):
+        """
+        check if a non-existing tag-wahoo xml file issues an exception
+        """
+        with self.assertRaises(TagWahooXmlNotFoundError):
+            fd_fct.get_tag_wahoo_xml_path("not_existing.xml")
+
+    def test_existing_tag_wahoo_xml(self):
+        """
+        check if the correct path of an existing tag-wahoo xml file is returned
+        """
+
+        expected_path = os.path.join(
+            constants.RESOURCES_DIR, "tag_wahoo_adjusted", "tag-wahoo-poi.xml")
+        self.assertEqual(fd_fct.get_tag_wahoo_xml_path(
+            "tag-wahoo-poi.xml"), expected_path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -1,5 +1,5 @@
 """
-tests for the downloader file
+tests for the osm maps file
 """
 import os
 # import sys

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -15,8 +15,13 @@ import requests
 
 # import custom python packages
 from wahoomc.constants import TOOLING_WIN_DIR
+from wahoomc.constants import RESOURCES_DIR
 
 log = logging.getLogger('main-logger')
+
+
+class TagWahooXmlNotFoundError(Exception):
+    """Raised when the specified tag-wahoo xml file does not exist"""
 
 
 def unzip(source_filename, dest_dir):
@@ -165,3 +170,17 @@ def get_tooling_win_path(path_in_tooling_win):
     return path to a tooling in the tooling_win directory and the given path
     """
     return os.path.join(TOOLING_WIN_DIR, *path_in_tooling_win)
+
+
+def get_tag_wahoo_xml_path(tag_wahoo_xml):
+    """
+    return path to tag-wahoo xml file if the file exists
+    """
+
+    path_tag_wahoo_xml = os.path.join(
+        RESOURCES_DIR, "tag_wahoo_adjusted", tag_wahoo_xml)
+
+    if os.path.exists(path_tag_wahoo_xml):
+        return path_tag_wahoo_xml
+
+    raise TagWahooXmlNotFoundError

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -24,7 +24,7 @@ def run():
     """
     # create logger
     logging.basicConfig(format='%(levelname)s:%(message)s',
-                        level=logging.DEBUG)
+                        level=logging.INFO)
 
     # handle GUI and CLI processing via one function and different cli-calls
     o_input_data = process_call_of_the_tool()

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -671,8 +671,13 @@ class OsmMaps:
                 cmd.append('zoom-interval-conf=10,0,17')
                 cmd.append('threads=' + threads)
                 # add path to tag-wahoo xml file
-                cmd.append(
-                    f'tag-conf-file={fd_fct.get_tag_wahoo_xml_path(tag_wahoo_xml)}')
+                try:
+                    cmd.append(
+                        f'tag-conf-file={fd_fct.get_tag_wahoo_xml_path(tag_wahoo_xml)}')
+                except fd_fct.TagWahooXmlNotFoundError:
+                    log.error(
+                        'The tag-wahoo xml file was not found: ˚%s˚. Does the file exist and is your input correct?', tag_wahoo_xml)
+                    sys.exit()
 
                 run_subprocess_and_log_output(
                     cmd, f'Error in creating map file via Osmosis with tile: {tile["x"]},{tile["y"]}. mapwriter plugin installed?')

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -670,9 +670,9 @@ class OsmMaps:
                     f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')
                 cmd.append('zoom-interval-conf=10,0,17')
                 cmd.append('threads=' + threads)
-                # should work on macOS and Windows
+                # add path to tag-wahoo xml file
                 cmd.append(
-                    f'tag-conf-file={os.path.join(RESOURCES_DIR, "tag_wahoo_adjusted", tag_wahoo_xml)}')
+                    f'tag-conf-file={fd_fct.get_tag_wahoo_xml_path(tag_wahoo_xml)}')
 
                 run_subprocess_and_log_output(
                     cmd, f'Error in creating map file via Osmosis with tile: {tile["x"]},{tile["y"]}. mapwriter plugin installed?')

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -478,7 +478,7 @@ class OsmMaps:
                         cmd.append('-o='+out_file)
 
                         run_subprocess_and_log_output(
-                            cmd, f'! Error in Osmosis with country: {country}')
+                            cmd, f'! Error in Osmosis with country: {country}. Win/out_file')
 
                         cmd = [self.osmconvert_path,
                                '-v', '--hash-memory=2500']
@@ -490,7 +490,7 @@ class OsmMaps:
                         cmd.append('-o='+out_file_names)
 
                         run_subprocess_and_log_output(
-                            cmd, '! Error in Osmosis with country: {country}')
+                            cmd, '! Error in Osmosis with country: {country}. Win/out_file_names')
 
                     # Non-Windows
                     else:
@@ -503,7 +503,7 @@ class OsmMaps:
                         cmd.extend(['--overwrite'])
 
                         run_subprocess_and_log_output(
-                            cmd, '! Error in Osmosis with country: {country}')
+                            cmd, '! Error in Osmosis with country: {country}. macOS/out_file')
 
                         cmd = ['osmium', 'extract']
                         cmd.extend(
@@ -514,7 +514,7 @@ class OsmMaps:
                         cmd.extend(['--overwrite'])
 
                         run_subprocess_and_log_output(
-                            cmd, '! Error in Osmosis with country: {country}')
+                            cmd, '! Error in Osmosis with country: {country}. macOS/out_file_names')
 
                         log.info(val['filtered_file'])
 
@@ -675,7 +675,7 @@ class OsmMaps:
                     f'tag-conf-file={os.path.join(RESOURCES_DIR, "tag_wahoo_adjusted", tag_wahoo_xml)}')
 
                 run_subprocess_and_log_output(
-                    cmd, f'Error in Osmosis with country: c // tile: {tile["x"]},{tile["y"]}')
+                    cmd, f'Error in creating map file via Osmosis with tile: {tile["x"]},{tile["y"]}. mapwriter plugin installed?')
 
                 # Windows
                 if platform.system() == "Windows":


### PR DESCRIPTION
## This PR…

- Makes loging clearer for troubleshooting: Distinguish between Osmosis errors
- Resets default logging level to INFO
- Refactors getting the tag-wahoo xml file path and unittest it

## Considerations and implementations

During figuring out what happens in #139 and with another user on telegram, it came out that the errors occuring while Osmosis processing were not really good, i.e. not easy to differentiate between them.
Furthermore I found that getting the tag-wahoo xml file is not unittested and errors there are not really caught up.

## How to test

1. Run the tool with a not-existing tag-wahoo xml file
2. Run the tool with a existing tag-wahoo xml file

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
