### PR TITLE
[FIX] handle threads as int and use f-typing to append it to cmd

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.0.2
+version = 2.1.0a5
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.1.0a5
+version = 2.0.2
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -643,7 +643,7 @@ class OsmMaps:
         log.info('# Creating .map files')
 
         # Number of threads to use in the mapwriter plug-in
-        threads = str(multiprocessing.cpu_count() - 1)
+        threads = multiprocessing.cpu_count() - 1
         if int(threads) < 1:
             threads = 1
 
@@ -669,7 +669,7 @@ class OsmMaps:
                 cmd.append(
                     f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')
                 cmd.append('zoom-interval-conf=10,0,17')
-                cmd.append('threads=' + threads)
+                cmd.append(f'threads={threads}')
                 # add path to tag-wahoo xml file
                 try:
                     cmd.append(


### PR DESCRIPTION
## This PR…

- fixes #143
- handles the `threads` variable consistent as integer and adds it via f-typing to the cmd command later on

## Considerations and implementations

- the variable `threads` was handled as string or as int depending on whether the if-statement was run throught or not.
https://github.com/treee111/wahooMapsCreator/blob/1b5f89f49554068cef0d0e9f2f874c939fe0c926/wahoomc/osm_maps_functions.py#L646-L648

- if handled as integer (e.g. Windows 10 running in VirtualBox), a TypeError is thrown because a integer can't be concatenated with a string this way
https://github.com/treee111/wahooMapsCreator/blob/1b5f89f49554068cef0d0e9f2f874c939fe0c926/wahoomc/osm_maps_functions.py#L672

## How to test

1. run this branch of wahooMapsCreator for a small country on Windows 10 in VirtualBox: `python -m wahoomc cli -co malta`
2. I created a alpha version, can also tested with v2.1.0a5: `pip install wahoo_mc==2.1.0a5`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
- [x] Windows 10 in VirtualBox
