### PR TITLE
[FIX] Set timeout for file downloads to 30 minutes per file (pylint finding)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.0.2
+version = 2.1.0a6
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.1.0a6
+version = 2.0.2
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -113,7 +113,9 @@ def download_url_to_file(url, map_file_path):
     """
     download the content of a ULR to file
     """
-    request_geofabrik = requests.get(url, allow_redirects=True, stream=True)
+    # set timeout to 30 minutes (per file)
+    request_geofabrik = requests.get(
+        url, allow_redirects=True, stream=True, timeout=1800)
     if request_geofabrik.status_code != 200:
         log.error('! failed download URL: %s', url)
         sys.exit()


### PR DESCRIPTION
## This PR…

- fixes a pylint finding which came up with a pylint version > 2.12.*

## How to test

1. process a small country with forcing the download: `python -m wahoomc cli -co malta -fd`
2. I created a alpha version, can also tested with v2.1.0a6: `pip install wahoo_mc==2.1.0a6`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
