### PR TITLE
[BREAKING] Process coding that can be influenced by user-input without `-fp` - speeds up playing with tags

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.1.0a13
+version = 2.1.0a14
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.0.2
+version = 2.1.0a13
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.1.0a14
+version = 2.0.2
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -604,60 +604,60 @@ class OsmMaps:
 
             land_files = glob.glob(os.path.join(out_tile_dir, 'land*.osm'))
 
-            if not os.path.isfile(out_file) or self.o_osm_data.force_processing is True:
-                # sort land* osm files
-                self.sort_osm_files(tile)
+            # merge splitted tiles with land and sea every time because the result is different per constants
+            # sort land* osm files
+            self.sort_osm_files(tile)
 
-                # Windows
-                if platform.system() == "Windows":
-                    cmd = [self.osmosis_win_file_path]
-                    loop = 0
-                    # loop through all countries of tile, if border-countries should be processed.
-                    # if border-countries should not be processed, only process the "entered" country
-                    for country in tile['countries']:
-                        if process_border_countries or country in self.o_osm_data.border_countries:
-                            cmd.append('--rbf')
-                            cmd.append(os.path.join(
-                                out_tile_dir, f'split-{country}.osm.pbf'))
-                            cmd.append('workers=' + self.workers)
-                            if loop > 0:
-                                cmd.append('--merge')
-
-                            cmd.append('--rbf')
-                            cmd.append(os.path.join(
-                                out_tile_dir, f'split-{country}-names.osm.pbf'))
-                            cmd.append('workers=' + self.workers)
+            # Windows
+            if platform.system() == "Windows":
+                cmd = [self.osmosis_win_file_path]
+                loop = 0
+                # loop through all countries of tile, if border-countries should be processed.
+                # if border-countries should not be processed, only process the "entered" country
+                for country in tile['countries']:
+                    if process_border_countries or country in self.o_osm_data.border_countries:
+                        cmd.append('--rbf')
+                        cmd.append(os.path.join(
+                            out_tile_dir, f'split-{country}.osm.pbf'))
+                        cmd.append('workers=' + self.workers)
+                        if loop > 0:
                             cmd.append('--merge')
 
-                            loop += 1
+                        cmd.append('--rbf')
+                        cmd.append(os.path.join(
+                            out_tile_dir, f'split-{country}-names.osm.pbf'))
+                        cmd.append('workers=' + self.workers)
+                        cmd.append('--merge')
 
-                    for land in land_files:
-                        cmd.extend(
-                            ['--rx', 'file='+os.path.join(out_tile_dir, f'{land}'), '--s', '--m'])
+                        loop += 1
+
+                for land in land_files:
                     cmd.extend(
-                        ['--rx', 'file='+os.path.join(out_tile_dir, 'sea.osm'), '--s', '--m'])
-                    cmd.extend(['--tag-transform', 'file=' + os.path.join(RESOURCES_DIR,
-                                                                          'tunnel-transform.xml'), '--wb', out_file, 'omitmetadata=true'])
+                        ['--rx', 'file='+os.path.join(out_tile_dir, f'{land}'), '--s', '--m'])
+                cmd.extend(
+                    ['--rx', 'file='+os.path.join(out_tile_dir, 'sea.osm'), '--s', '--m'])
+                cmd.extend(['--tag-transform', 'file=' + os.path.join(RESOURCES_DIR,
+                                                                      'tunnel-transform.xml'), '--wb', out_file, 'omitmetadata=true'])
 
-                # Non-Windows
-                else:
-                    cmd = ['osmium', 'merge', '--overwrite']
-                    # loop through all countries of tile, if border-countries should be processed.
-                    # if border-countries should not be processed, only process the "entered" country
-                    for country in tile['countries']:
-                        if process_border_countries or country in self.o_osm_data.border_countries:
-                            cmd.append(os.path.join(
-                                out_tile_dir, f'split-{country}.osm.pbf'))
-                            cmd.append(os.path.join(
-                                out_tile_dir, f'split-{country}-names.osm.pbf'))
+            # Non-Windows
+            else:
+                cmd = ['osmium', 'merge', '--overwrite']
+                # loop through all countries of tile, if border-countries should be processed.
+                # if border-countries should not be processed, only process the "entered" country
+                for country in tile['countries']:
+                    if process_border_countries or country in self.o_osm_data.border_countries:
+                        cmd.append(os.path.join(
+                            out_tile_dir, f'split-{country}.osm.pbf'))
+                        cmd.append(os.path.join(
+                            out_tile_dir, f'split-{country}-names.osm.pbf'))
 
-                    for land in land_files:
-                        cmd.append(land)
-                    cmd.append(os.path.join(out_tile_dir, 'sea.osm'))
-                    cmd.extend(['-o', out_file])
+                for land in land_files:
+                    cmd.append(land)
+                cmd.append(os.path.join(out_tile_dir, 'sea.osm'))
+                cmd.extend(['-o', out_file])
 
-                run_subprocess_and_log_output(
-                    cmd, f'! Error in Osmosis with tile: {tile["x"]},{tile["y"]}')
+            run_subprocess_and_log_output(
+                cmd, f'! Error in Osmosis with tile: {tile["x"]},{tile["y"]}')
 
             tile_count += 1
 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -326,7 +326,12 @@ class OsmMaps:
                 out_file_o5m_filtered_names = os.path.join(USER_OUTPUT_DIR,
                                                            f'outFileFiltered-{key}-Names.o5m')
 
-                if not os.path.isfile(out_file_o5m_filtered) or self.o_osm_data.force_processing is True:
+                if self.o_osm_data.force_processing is True:
+                    os.remove(out_file_o5m)
+                else:
+                    log.info('+ map of %s already in o5m format', key)
+
+                if not os.path.isfile(out_file_o5m):
                     log.info('+ Converting map of %s to o5m format', key)
                     cmd = [self.osmconvert_path]
                     cmd.extend(['-v', '--hash-memory=2500', '--complete-ways',
@@ -338,6 +343,7 @@ class OsmMaps:
                     run_subprocess_and_log_output(
                         cmd, '! Error in OSMConvert with country: {key}')
 
+                if not os.path.isfile(out_file_o5m_filtered) or self.o_osm_data.force_processing is True:
                     log.info(
                         '+ Filtering unwanted map objects out of map of %s', key)
                     cmd = [get_tooling_win_path(['osmfilter'])]
@@ -363,8 +369,6 @@ class OsmMaps:
 
                     run_subprocess_and_log_output(
                         cmd, '! Error in OSMFilter with country: {key}')
-
-                    os.remove(out_file_o5m)
 
                 val['filtered_file'] = out_file_o5m_filtered
                 val['filtered_file_names'] = out_file_o5m_filtered_names

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -528,58 +528,59 @@ class OsmMaps:
                                               f'{tile["x"]}', f'{tile["y"]}', f'split-{country}-names.osm.pbf')
                 out_merged = os.path.join(USER_OUTPUT_DIR,
                                           f'{tile["x"]}', f'{tile["y"]}', 'merged.osm.pbf')
-                if not os.path.isfile(out_merged) or self.o_osm_data.force_processing is True:
-                    # Windows
-                    if platform.system() == "Windows":
-                        cmd = [self.osmconvert_path,
-                               '-v', '--hash-memory=2500']
-                        cmd.append('-b='+f'{tile["left"]}' + ',' + f'{tile["bottom"]}' +
-                                   ',' + f'{tile["right"]}' + ',' + f'{tile["top"]}')
-                        cmd.extend(
-                            ['--complete-ways', '--complete-multipolygons', '--complete-boundaries'])
-                        cmd.append(val['filtered_file'])
-                        cmd.append('-o='+out_file)
 
-                        run_subprocess_and_log_output(
-                            cmd, f'! Error in Osmosis with country: {country}. Win/out_file')
+                # split filtered country files to tiles every time because the result is different per constants
+                # Windows
+                if platform.system() == "Windows":
+                    cmd = [self.osmconvert_path,
+                           '-v', '--hash-memory=2500']
+                    cmd.append('-b='+f'{tile["left"]}' + ',' + f'{tile["bottom"]}' +
+                               ',' + f'{tile["right"]}' + ',' + f'{tile["top"]}')
+                    cmd.extend(
+                        ['--complete-ways', '--complete-multipolygons', '--complete-boundaries'])
+                    cmd.append(val['filtered_file'])
+                    cmd.append('-o='+out_file)
 
-                        cmd = [self.osmconvert_path,
-                               '-v', '--hash-memory=2500']
-                        cmd.append('-b='+f'{tile["left"]}' + ',' + f'{tile["bottom"]}' +
-                                   ',' + f'{tile["right"]}' + ',' + f'{tile["top"]}')
-                        cmd.extend(
-                            ['--complete-ways', '--complete-multipolygons', '--complete-boundaries'])
-                        cmd.append(val['filtered_file_names'])
-                        cmd.append('-o='+out_file_names)
+                    run_subprocess_and_log_output(
+                        cmd, f'! Error in Osmosis with country: {country}. Win/out_file')
 
-                        run_subprocess_and_log_output(
-                            cmd, '! Error in Osmosis with country: {country}. Win/out_file_names')
+                    cmd = [self.osmconvert_path,
+                           '-v', '--hash-memory=2500']
+                    cmd.append('-b='+f'{tile["left"]}' + ',' + f'{tile["bottom"]}' +
+                               ',' + f'{tile["right"]}' + ',' + f'{tile["top"]}')
+                    cmd.extend(
+                        ['--complete-ways', '--complete-multipolygons', '--complete-boundaries'])
+                    cmd.append(val['filtered_file_names'])
+                    cmd.append('-o='+out_file_names)
 
-                    # Non-Windows
-                    else:
-                        cmd = ['osmium', 'extract']
-                        cmd.extend(
-                            ['-b', f'{tile["left"]},{tile["bottom"]},{tile["right"]},{tile["top"]}'])
-                        cmd.append(val['filtered_file'])
-                        cmd.extend(['-s', 'smart'])
-                        cmd.extend(['-o', out_file])
-                        cmd.extend(['--overwrite'])
+                    run_subprocess_and_log_output(
+                        cmd, '! Error in Osmosis with country: {country}. Win/out_file_names')
 
-                        run_subprocess_and_log_output(
-                            cmd, '! Error in Osmosis with country: {country}. macOS/out_file')
+                # Non-Windows
+                else:
+                    cmd = ['osmium', 'extract']
+                    cmd.extend(
+                        ['-b', f'{tile["left"]},{tile["bottom"]},{tile["right"]},{tile["top"]}'])
+                    cmd.append(val['filtered_file'])
+                    cmd.extend(['-s', 'smart'])
+                    cmd.extend(['-o', out_file])
+                    cmd.extend(['--overwrite'])
 
-                        cmd = ['osmium', 'extract']
-                        cmd.extend(
-                            ['-b', f'{tile["left"]},{tile["bottom"]},{tile["right"]},{tile["top"]}'])
-                        cmd.append(val['filtered_file_names'])
-                        cmd.extend(['-s', 'smart'])
-                        cmd.extend(['-o', out_file_names])
-                        cmd.extend(['--overwrite'])
+                    run_subprocess_and_log_output(
+                        cmd, '! Error in Osmosis with country: {country}. macOS/out_file')
 
-                        run_subprocess_and_log_output(
-                            cmd, '! Error in Osmosis with country: {country}. macOS/out_file_names')
+                    cmd = ['osmium', 'extract']
+                    cmd.extend(
+                        ['-b', f'{tile["left"]},{tile["bottom"]},{tile["right"]},{tile["top"]}'])
+                    cmd.append(val['filtered_file_names'])
+                    cmd.extend(['-s', 'smart'])
+                    cmd.extend(['-o', out_file_names])
+                    cmd.extend(['--overwrite'])
 
-                        log.info(val['filtered_file'])
+                    run_subprocess_and_log_output(
+                        cmd, '! Error in Osmosis with country: {country}. macOS/out_file_names')
+
+                    log.info(val['filtered_file'])
 
             tile_count += 1
 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -308,7 +308,7 @@ class OsmMaps:
         create_empty_directories(
             USER_OUTPUT_DIR, self.o_osm_data.tiles)
 
-    def filter_tags_from_country_osm_pbf_files(self):
+    def filter_tags_from_country_osm_pbf_files(self):  # pylint: disable=too-many-statements
         """
         Filter tags from country osm.pbf files
         """
@@ -329,8 +329,9 @@ class OsmMaps:
                 if self.o_osm_data.force_processing is True:
                     os.remove(out_file_o5m)
                 else:
-                    log.info('+ map of %s already in o5m format', key)
+                    log.info('+ Map of %s already in o5m format', key)
 
+                # only create o5m file if not there already --> speeds up processing if one only wants to test tags / POIs
                 if not os.path.isfile(out_file_o5m):
                     log.info('+ Converting map of %s to o5m format', key)
                     cmd = [self.osmconvert_path]

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -526,8 +526,6 @@ class OsmMaps:
                                         f'{tile["x"]}', f'{tile["y"]}', f'split-{country}.osm.pbf')
                 out_file_names = os.path.join(USER_OUTPUT_DIR,
                                               f'{tile["x"]}', f'{tile["y"]}', f'split-{country}-names.osm.pbf')
-                out_merged = os.path.join(USER_OUTPUT_DIR,
-                                          f'{tile["x"]}', f'{tile["y"]}', 'merged.osm.pbf')
 
                 # split filtered country files to tiles every time because the result is different per constants
                 # Windows

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -326,16 +326,8 @@ class OsmMaps:
                 out_file_o5m_filtered_names = os.path.join(USER_OUTPUT_DIR,
                                                            f'outFileFiltered-{key}-Names.o5m')
 
-                if self.o_osm_data.force_processing is True:
-                    try:
-                        os.remove(out_file_o5m)
-                    except OSError:
-                        pass
-                else:
-                    log.info('+ Map of %s already in o5m format', key)
-
                 # only create o5m file if not there already --> speeds up processing if one only wants to test tags / POIs
-                if not os.path.isfile(out_file_o5m):
+                if not os.path.isfile(out_file_o5m) or self.o_osm_data.force_processing is True:
                     log.info('+ Converting map of %s to o5m format', key)
                     cmd = [self.osmconvert_path]
                     cmd.extend(['-v', '--hash-memory=2500', '--complete-ways',
@@ -346,33 +338,36 @@ class OsmMaps:
 
                     run_subprocess_and_log_output(
                         cmd, '! Error in OSMConvert with country: {key}')
+                else:
+                    log.info('+ Map of %s already in o5m format', key)
 
-                if not os.path.isfile(out_file_o5m_filtered) or self.o_osm_data.force_processing is True:
-                    log.info(
-                        '+ Filtering unwanted map objects out of map of %s', key)
-                    cmd = [get_tooling_win_path(['osmfilter'])]
-                    cmd.append(out_file_o5m)
-                    cmd.append(
-                        '--keep="' + translate_tags_to_keep(sys_platform=platform.system()) + '"')
-                    cmd.append('--keep-tags="all type= layer= ' +
-                               translate_tags_to_keep(sys_platform=platform.system()) + '"')
-                    cmd.append('-o=' + out_file_o5m_filtered)
+                # filter out tags every time using the defined TAGS_TO_KEEP_UNIVERSAL constants
+                # because the result is different per constants
+                log.info(
+                    '+ Filtering unwanted map objects out of map of %s', key)
+                cmd = [get_tooling_win_path(['osmfilter'])]
+                cmd.append(out_file_o5m)
+                cmd.append(
+                    '--keep="' + translate_tags_to_keep(sys_platform=platform.system()) + '"')
+                cmd.append('--keep-tags="all type= layer= ' +
+                           translate_tags_to_keep(sys_platform=platform.system()) + '"')
+                cmd.append('-o=' + out_file_o5m_filtered)
 
-                    run_subprocess_and_log_output(
-                        cmd, '! Error in OSMFilter with country: {key}')
+                run_subprocess_and_log_output(
+                    cmd, '! Error in OSMFilter with country: {key}')
 
-                    cmd = [get_tooling_win_path(['osmfilter'])]
-                    cmd.append(out_file_o5m)
-                    cmd.append(
-                        '--keep="' + translate_tags_to_keep(
-                            name_tags=True, sys_platform=platform.system()) + '"')
-                    cmd.append('--keep-tags="all type= name= layer= ' +
-                               translate_tags_to_keep(
-                                   name_tags=True, sys_platform=platform.system()) + '"')
-                    cmd.append('-o=' + out_file_o5m_filtered_names)
+                cmd = [get_tooling_win_path(['osmfilter'])]
+                cmd.append(out_file_o5m)
+                cmd.append(
+                    '--keep="' + translate_tags_to_keep(
+                        name_tags=True, sys_platform=platform.system()) + '"')
+                cmd.append('--keep-tags="all type= name= layer= ' +
+                           translate_tags_to_keep(
+                               name_tags=True, sys_platform=platform.system()) + '"')
+                cmd.append('-o=' + out_file_o5m_filtered_names)
 
-                    run_subprocess_and_log_output(
-                        cmd, '! Error in OSMFilter with country: {key}')
+                run_subprocess_and_log_output(
+                    cmd, '! Error in OSMFilter with country: {key}')
 
                 val['filtered_file'] = out_file_o5m_filtered
                 val['filtered_file_names'] = out_file_o5m_filtered_names

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -327,7 +327,10 @@ class OsmMaps:
                                                            f'outFileFiltered-{key}-Names.o5m')
 
                 if self.o_osm_data.force_processing is True:
-                    os.remove(out_file_o5m)
+                    try:
+                        os.remove(out_file_o5m)
+                    except OSError:
+                        pass
                 else:
                     log.info('+ Map of %s already in o5m format', key)
 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -344,7 +344,7 @@ class OsmMaps:
                     cmd.append(out_file_o5m)
                     cmd.append(
                         '--keep="' + translate_tags_to_keep(sys_platform=platform.system()) + '"')
-                    cmd.append('--keep-tags=all type= layer= "' +
+                    cmd.append('--keep-tags="all type= layer= ' +
                                translate_tags_to_keep(sys_platform=platform.system()) + '"')
                     cmd.append('-o=' + out_file_o5m_filtered)
 
@@ -356,7 +356,7 @@ class OsmMaps:
                     cmd.append(
                         '--keep="' + translate_tags_to_keep(
                             name_tags=True, sys_platform=platform.system()) + '"')
-                    cmd.append('--keep-tags=all type= name= layer= "' +
+                    cmd.append('--keep-tags="all type= name= layer= ' +
                                translate_tags_to_keep(
                                    name_tags=True, sys_platform=platform.system()) + '"')
                     cmd.append('-o=' + out_file_o5m_filtered_names)

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -326,7 +326,8 @@ class OsmMaps:
                 out_file_o5m_filtered_names = os.path.join(USER_OUTPUT_DIR,
                                                            f'outFileFiltered-{key}-Names.o5m')
 
-                # only create o5m file if not there already --> speeds up processing if one only wants to test tags / POIs
+                # only create o5m file if not there already or force processing (no user input possible)
+                # --> speeds up processing if one only wants to test tags / POIs
                 if not os.path.isfile(out_file_o5m) or self.o_osm_data.force_processing is True:
                     log.info('+ Converting map of %s to o5m format', key)
                     cmd = [self.osmconvert_path]
@@ -342,7 +343,7 @@ class OsmMaps:
                     log.info('+ Map of %s already in o5m format', key)
 
                 # filter out tags every time using the defined TAGS_TO_KEEP_UNIVERSAL constants
-                # because the result is different per constants
+                # because the result is different per constants (user input)
                 log.info(
                     '+ Filtering unwanted map objects out of map of %s', key)
                 cmd = [get_tooling_win_path(['osmfilter'])]
@@ -527,7 +528,7 @@ class OsmMaps:
                 out_file_names = os.path.join(USER_OUTPUT_DIR,
                                               f'{tile["x"]}', f'{tile["y"]}', f'split-{country}-names.osm.pbf')
 
-                # split filtered country files to tiles every time because the result is different per constants
+                # split filtered country files to tiles every time because the result is different per constants (user input)
                 # Windows
                 if platform.system() == "Windows":
                     cmd = [self.osmconvert_path,
@@ -602,7 +603,7 @@ class OsmMaps:
 
             land_files = glob.glob(os.path.join(out_tile_dir, 'land*.osm'))
 
-            # merge splitted tiles with land and sea every time because the result is different per constants
+            # merge splitted tiles with land and sea every time because the result is different per constants (user input)
             # sort land* osm files
             self.sort_osm_files(tile)
 
@@ -716,7 +717,7 @@ class OsmMaps:
             out_file = os.path.join(USER_OUTPUT_DIR,
                                     f'{tile["x"]}', f'{tile["y"]}.map')
 
-            # apply tag-wahoo xml every time because the result is different per user input
+            # apply tag-wahoo xml every time because the result is different per .xml file (user input)
             merged_file = os.path.join(USER_OUTPUT_DIR,
                                        f'{tile["x"]}', f'{tile["y"]}', 'merged.osm.pbf')
 


### PR DESCRIPTION
## This PR…

- Enhances function `filter_tags_from_country_osm_pbf_files` to speed up processing when playing with filtering tags / tag-mapping / tag-transform

## Considerations and implementations

Coding that can be influeced by user-input:
- Filtering unwanted map objects out of maps
- Splitting filtered country files to tiles
- Merging splitted tiles with land and sea
- Creating map tiles - apply tag-wahoo xml

Coding that can not be influeced by user-input:
- Converting map to o5m format (Windows only)

## How to test

checkout this branch or install version v2.1.0a14 via `pip install wahoo_mc==2.1.0a14`

1. Run `python -m wahoomc cli -co malta -tag tag-wahoo.xml -fp`
2. check size and content of generated maps
3. `python -m wahoomc cli -co malta -tag tag-wahoo-poi.xml`
4. check size and content of generated maps

The files from 2. and 4. should be different. This would show, that the both .xml files have done their job.

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
