### PR TITLE
[BREAKING] By default include POI's into generated maps

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -69,18 +69,13 @@ To create maps for only one tile and not a whole country, one can use the X/Y co
 
 ## POIs - Points of Interest
 For creating maps which include POIs and have them displayed on your Wahoo device, these steps need to be done:
-1. Create custom maps including POIs
-  - a) via CLI
-     - `python -m wahoomc cli -co malta -tag tag-wahoo-poi.xml`
-  - b) via GUI
-     - `python -m wahoomc gui`
-     - Fill into Advanced-->Tag wahoo XML file: `tag-wahoo-poi.xml`
+1. Create custom maps including POIs like [normally](#run-wahoomapscreator-for-your-country), POI's are included per default.
 
-By using the tag-wahoo-poi.xml file, wahooMapsCreator includes fuel stations, backeries, cafes and railway stations POI's into the generated maps. 
+Actually, wahooMapsCreator includes fuel stations, backeries, cafes and railway stations POI's into the generated maps. 
 
 2. Copy POIs relevant files to your device
 - [:floppy_disk: docu](COPY_TO_WAHOO.md#copy-relevant-files-for-pois)
 
-1. Activate VTM rendering if needed
+3. Activate VTM rendering if needed
 - [see here](COPY_TO_WAHOO.md#activate-vtm-rendering)
 - see also: https://github.com/treee111/wahooMapsCreator/wiki/Enable-hidden-features

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -149,7 +149,7 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
         self.save_cruiser = False
         self.only_merge = False
 
-        self.tag_wahoo_xml = "tag-wahoo.xml"
+        self.tag_wahoo_xml = "tag-wahoo-poi.xml"
 
         # Way of calculating the relevant tiles for given input (country)
         # True - Use geofabrik index-v1.json file


### PR DESCRIPTION
## This PR…

- introduces the tag-wahoo .xml file for including POI's as default

## Considerations and implementations

As most of the people use wahooMapsCreator to create maps including POI's, this is now _golden_ standard.

## How to test

1. `python -m wahoomc cli -co malta`
2. check if created maps have POI's included

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
