### PR TITLE
[FEAT] Refactor a lot to decouple and make maintenance easier (focus osm_maps_functions.py)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 2.0.2
+version = 2.1.0a13
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -83,6 +83,25 @@ class TestDownloader(unittest.TestCase):
 
         self.assertTrue(os.path.exists(path))
 
+    def test_download_geofabrik_file_2(self):
+        """
+        Test the download of geofabrik file via URL.
+        check & download via built functions of downloader class
+        """
+        path = os.path.join(constants.USER_DL_DIR, 'geofabrik.json')
+
+        if os.path.exists(path):
+            os.remove(path)
+
+        self.assertTrue(
+            self.o_downloader.should_geofabrik_file_be_downloaded())
+
+        self.o_downloader.download_geofabrik_file()
+
+        self.assertTrue(os.path.exists(path))
+        self.assertFalse(
+            self.o_downloader.should_geofabrik_file_be_downloaded())
+
     def test_download_malta_osm_pbf_file(self):
         """
         Test the download of geofabrik file via URL
@@ -114,6 +133,21 @@ class TestDownloader(unittest.TestCase):
 
         with self.assertRaises(FileNotFoundError):
             os.remove(path)
+
+    def test_check_dl_needed_geofabrik(self):
+        """
+        Test if geofabrik file needs to be downloaded
+        """
+        path = os.path.join(constants.USER_DL_DIR, 'geofabrik.json')
+
+        if os.path.exists(path):
+            os.remove(path)
+
+        self.o_downloader.max_days_old = 24
+        # self.o_downloader.check_geofabrik_file()
+
+        self.assertTrue(
+            self.o_downloader.should_geofabrik_file_be_downloaded())
 
 
 if __name__ == '__main__':

--- a/tests/test_geofabrik.py
+++ b/tests/test_geofabrik.py
@@ -46,7 +46,7 @@ class TestGeofabrik(unittest.TestCase):
 
         if not os.path.isfile(constants.GEOFABRIK_PATH):
             o_downloader = Downloader(24, False)
-            o_downloader.check_and_download_geofabrik_if_needed()
+            o_downloader.download_geofabrik_file()
 
     def test_tiles_via_geofabrik_malta(self):
         """

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -8,7 +8,7 @@ import unittest
 # import custom python packages
 # sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from wahoomc.osm_maps_functions import OsmMaps
+from wahoomc.osm_maps_functions import OsmData
 from wahoomc.osm_maps_functions import get_tile_by_one_xy_combination_from_jsons
 from wahoomc.osm_maps_functions import get_xy_coordinates_from_input
 from wahoomc.osm_maps_functions import TileNotFoundError
@@ -23,10 +23,7 @@ class TestOsmMaps(unittest.TestCase):
     tests for the OSM maps file
     """
 
-    def setUp(self):
-        o_input_data = InputData()
-
-        self.o_osm_maps = OsmMaps(o_input_data)
+    # def setUp(self):
 
     def test_input_country_malta(self):
         """
@@ -34,10 +31,13 @@ class TestOsmMaps(unittest.TestCase):
         check, if the given input-parameter is saved to the OsmMaps instance
         """
 
-        self.o_osm_maps.o_input_data.country = 'malta'
-        self.o_osm_maps.process_input(True)
+        o_input_data = InputData()
+        o_input_data.country = 'malta'
 
-        result = self.o_osm_maps.o_osm_data.country_name
+        o_osm_data = OsmData()
+        o_osm_data.process_input_of_the_tool(o_input_data)
+
+        result = o_osm_data.country_name
         self.assertEqual(result, 'malta')
 
     def test_calc_border_countries_input_country(self):
@@ -123,13 +123,17 @@ class TestOsmMaps(unittest.TestCase):
         helper method to process a country or json file and check the calculated border countries
         """
 
+        o_input_data = InputData()
         if inp_mode == 'country':
-            self.o_osm_maps.o_input_data.country = inp_val
+            o_input_data.country = inp_val
         elif inp_mode == 'xy_coordinate':
-            self.o_osm_maps.o_input_data.xy_coordinates = inp_val
+            o_input_data.xy_coordinates = inp_val
+        o_input_data.process_border_countries = calc_border_c
 
-        self.o_osm_maps.process_input(calc_border_c)
-        result = self.o_osm_maps.o_osm_data.border_countries
+        o_osm_data = OsmData()
+        o_osm_data.process_input_of_the_tool(o_input_data)
+
+        result = o_osm_data.border_countries
 
         self.assertEqual(result, exp_result)
 

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -37,7 +37,7 @@ class TestOsmMaps(unittest.TestCase):
         self.o_osm_maps.o_input_data.country = 'malta'
         self.o_osm_maps.process_input(True)
 
-        result = self.o_osm_maps.country_name
+        result = self.o_osm_maps.o_osm_data.country_name
         self.assertEqual(result, 'malta')
 
     def test_calc_border_countries_input_country(self):
@@ -129,7 +129,7 @@ class TestOsmMaps(unittest.TestCase):
             self.o_osm_maps.o_input_data.xy_coordinates = inp_val
 
         self.o_osm_maps.process_input(calc_border_c)
-        result = self.o_osm_maps.border_countries
+        result = self.o_osm_maps.o_osm_data.border_countries
 
         self.assertEqual(result, exp_result)
 

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -135,7 +135,14 @@ class TestOsmMaps(unittest.TestCase):
 
         result = o_osm_data.border_countries
 
+        # delete the path to the file, here, only the correct border countries are checked
+        for res in result:
+            result[res] = {}
+
+        # self.assertEqual(result, exp_result)
         self.assertEqual(result, exp_result)
+
+        # self.assertDictEqual()  Equal(tIn(member=exp_result, container=result)
 
 
 class TestStaticJsons(unittest.TestCase):

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -86,7 +86,7 @@ class Downloader:
     This is the class to check and download maps / artifacts"
     """
 
-    def __init__(self, max_days_old, force_download, tiles_from_json, border_countries):
+    def __init__(self, max_days_old, force_download, tiles_from_json=None, border_countries=None):
         self.max_days_old = max_days_old
         self.force_download = force_download
         self.tiles_from_json = tiles_from_json
@@ -109,7 +109,7 @@ class Downloader:
 
         return False
 
-    def download_geofabrik_file(self):
+    def download_geofabrik_file(self): # pylint: disable=no-self-use
         """
         download geofabrik file
         """

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -108,7 +108,7 @@ class Downloader:
 
         return False
 
-    def download_geofabrik_file(self):  # pylint: disable=no-self-use
+    def download_geofabrik_file(self):
         """
         download geofabrik file
         """

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -12,10 +12,9 @@ import time
 import logging
 
 # import custom python packages
-from wahoomc import file_directory_functions as fd_fct
-from wahoomc import constants_functions as const_fct
+from wahoomc.file_directory_functions import download_url_to_file, unzip
+from wahoomc.constants_functions import translate_country_input_to_geofabrik, get_geofabrik_region_of_country
 
-# User
 from wahoomc.constants import USER_DL_DIR
 from wahoomc.constants import USER_MAPS_DIR
 from wahoomc.constants import LAND_POLYGONS_PATH
@@ -45,14 +44,14 @@ def download_file(target_filepath, url, is_zip):
         last_part = url.rsplit('/', 1)[-1]
         dl_file_path = os.path.join(USER_DL_DIR, last_part)
         # download URL to file
-        fd_fct.download_url_to_file(url, dl_file_path)
+        download_url_to_file(url, dl_file_path)
         # unpack it - should work on macOS and Windows
-        fd_fct.unzip(dl_file_path, USER_DL_DIR)
+        unzip(dl_file_path, USER_DL_DIR)
         # delete .zip file
         os.remove(dl_file_path)
     else:
         # no zipping --> directly download to given target filepath
-        fd_fct.download_url_to_file(url, target_filepath)
+        download_url_to_file(url, target_filepath)
     # Check if file exists (if target file exists)
     if not os.path.isfile(target_filepath):
         log.error('! failed to find %s', target_filepath)
@@ -66,8 +65,8 @@ def get_osm_pbf_filepath_url(country):
     build the geofabrik download url to a countries' OSM file and download filepath
     """
 
-    transl_c = const_fct.translate_country_input_to_geofabrik(country)
-    region = const_fct.get_geofabrik_region_of_country(country)
+    transl_c = translate_country_input_to_geofabrik(country)
+    region = get_geofabrik_region_of_country(country)
     if region != 'no':
         url = 'https://download.geofabrik.de/' + region + \
             '/' + transl_c + '-latest.osm.pbf'
@@ -109,7 +108,7 @@ class Downloader:
 
         return False
 
-    def download_geofabrik_file(self): # pylint: disable=no-self-use
+    def download_geofabrik_file(self):  # pylint: disable=no-self-use
         """
         download geofabrik file
         """
@@ -187,7 +186,7 @@ class Downloader:
             # get translated country (geofabrik) of country
             # do not download the same file for different countries
             # --> e.g. China, Hong Kong and Macao, see Issue #11
-            transl_c = const_fct.translate_country_input_to_geofabrik(country)
+            transl_c = translate_country_input_to_geofabrik(country)
 
             # check for already existing .osm.pbf file
             map_file_path = glob.glob(

--- a/wahoomc/geofabrik.py
+++ b/wahoomc/geofabrik.py
@@ -12,7 +12,8 @@ import geojson
 from shapely.geometry import Polygon, shape
 
 # import custom python packages
-from wahoomc import constants
+from wahoomc.constants import GEOFABRIK_PATH
+from wahoomc.constants import special_regions, geofabrik_regions, block_download
 
 log = logging.getLogger('main-logger')
 
@@ -142,7 +143,7 @@ def geom(wanted):
     input parameter is the name of the desired country/region as use by Geofabric
     in their json file.
     """
-    with open(constants.GEOFABRIK_PATH, encoding='utf8') as file_handle:
+    with open(GEOFABRIK_PATH, encoding='utf8') as file_handle:
         data = geojson.load(file_handle)
     file_handle.close()
 
@@ -196,7 +197,7 @@ def find_needed_countries(bbox_tiles, wanted_map, wanted_region_polygon):
     """
     output = []
 
-    with open(constants.GEOFABRIK_PATH, encoding='utf8') as file_handle:
+    with open(GEOFABRIK_PATH, encoding='utf8') as file_handle:
         geofabrik_json_data = geojson.load(file_handle)
     file_handle.close()
 
@@ -244,19 +245,19 @@ def find_needed_countries(bbox_tiles, wanted_map, wanted_region_polygon):
                 if rshape.intersects(poly):  # if so
                     # catch special_regions like (former) colonies where the map of the region is not fysically in the map of the parent country.
                     # example Guadeloupe, it's parent country is France but Guadeloupe is not located within the region covered by the map of France
-                    if wanted_map not in constants.special_regions:
+                    if wanted_map not in special_regions:
                         # If we are proseccing a sub-region add the parent of this sub-region
                         # to the must download list.
                         # This to prevent downloading several small regions AND it's containing region
                         # we are processing a sub-regiongo find the parent region:
-                        if parent not in constants.geofabrik_regions and regionname not in constants.geofabrik_regions:
+                        if parent not in geofabrik_regions and regionname not in geofabrik_regions:
                             # we are processing a sub-regiongo find the parent region
                             x_value = 0
                             # handle sub-sub-regions like unterfranken->bayern->germany
-                            while parent not in constants.geofabrik_regions:
+                            while parent not in geofabrik_regions:
                                 parent, child = find_geofbrik_parent(
                                     parent, geofabrik_json_data)
-                                if parent in constants.geofabrik_regions:
+                                if parent in geofabrik_regions:
                                     parent = child
                                     break
                                 if x_value > 10:  # prevent endless loop
@@ -288,7 +289,7 @@ def find_needed_countries(bbox_tiles, wanted_map, wanted_region_polygon):
             if regionname != wanted_map:
                 # check if we are processing a country or a sub-region.
                 # For countries only process other countries. also block special geofabrik sub regions
-                if parent in constants.geofabrik_regions and regionname not in constants.block_download:
+                if parent in geofabrik_regions and regionname not in block_download:
                     # processing a country and no special sub-region
                     # check if rshape is subset of desired region. If so discard it
                     if wanted_region_polygon.contains(rshape):

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -172,6 +172,9 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
                          "Or in the GUI select a country to create maps for.")
             else:
                 sys.exit()
+        elif self.country and self.xy_coordinates:
+            sys.exit(
+                "Country and X/Y coordinates are given. Only one of both is allowed!")
         else:
             return True
 

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -37,15 +37,13 @@ def run():
     move_old_content_into_new_dirs()
 
     o_osm_data = OsmData()
-    o_osm_data.process_input_of_the_tool(o_input_data)
+    # Check for not existing or expired files. Mark for download, if dl is needed
+    o_downloader = o_osm_data.process_input_of_the_tool(o_input_data)
 
-    o_osm_maps = OsmMaps(o_input_data, o_osm_data)
+    # Download files marked for download
+    o_downloader.download_files_if_needed()
 
-    # Read json file
-    # Check for expired land polygons file and download, if too old
-    # Check for expired .osm.pbf files and download, if too old
-    # o_osm_maps.process_input(o_input_data.process_border_countries)
-    o_osm_maps.check_and_download_files()
+    o_osm_maps = OsmMaps(o_osm_data)
 
     if o_input_data.only_merge is False:
         # Filter tags from country osm.pbf files'

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -11,7 +11,7 @@ from wahoomc.input import process_call_of_the_tool
 from wahoomc.setup_functions import initialize_work_directories
 from wahoomc.setup_functions import move_old_content_into_new_dirs
 from wahoomc.osm_maps_functions import OsmMaps
-# from wahoomc.osm_maps_functions import OsmData
+from wahoomc.osm_maps_functions import OsmData
 
 # logging used in the terminal output:
 # # means top-level command
@@ -36,9 +36,10 @@ def run():
     initialize_work_directories()
     move_old_content_into_new_dirs()
 
-    # o_osm_data = OsmData(o_input_data)
+    o_osm_data = OsmData()
+    o_osm_data.process_input_of_the_tool(o_input_data)
 
-    o_osm_maps = OsmMaps(o_input_data)
+    o_osm_maps = OsmMaps(o_input_data, o_osm_data)
 
     # Read json file
     # Check for expired land polygons file and download, if too old

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -11,6 +11,7 @@ from wahoomc.input import process_call_of_the_tool
 from wahoomc.setup_functions import initialize_work_directories
 from wahoomc.setup_functions import move_old_content_into_new_dirs
 from wahoomc.osm_maps_functions import OsmMaps
+# from wahoomc.osm_maps_functions import OsmData
 
 # logging used in the terminal output:
 # # means top-level command
@@ -35,12 +36,14 @@ def run():
     initialize_work_directories()
     move_old_content_into_new_dirs()
 
+    # o_osm_data = OsmData(o_input_data)
+
     o_osm_maps = OsmMaps(o_input_data)
 
     # Read json file
     # Check for expired land polygons file and download, if too old
     # Check for expired .osm.pbf files and download, if too old
-    o_osm_maps.process_input(o_input_data.process_border_countries)
+    # o_osm_maps.process_input(o_input_data.process_border_countries)
     o_osm_maps.check_and_download_files()
 
     if o_input_data.only_merge is False:

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -117,7 +117,6 @@ class OsmData():  # pylint: disable=too-few-public-methods
             o_input_data.max_days_old, o_input_data.force_download)
 
         self.force_processing = ''
-
         self.tiles = []
 
         log.info('-' * 80)
@@ -164,13 +163,12 @@ class OsmData():  # pylint: disable=too-few-public-methods
                 self.find_tiles_for_xy_combinations(xy_coordinates)
 
             # calc border country when input X/Y coordinates
-            calc_border_countries = True
+            o_input_data.process_border_countries = True
 
         # Build list of countries needed, either via CLI/GUI input or if processing x/y coordinates
         self.border_countries = {}
-        if o_input_data.process_border_countries or calc_border_countries:
-            self.calc_border_countries(True)
-        else:
+        self.calc_border_countries(o_input_data.process_border_countries)
+        if not o_input_data.process_border_countries:
             self.border_countries[self.country_name] = {}
 
         if 8 * struct.calcsize("P") == 32:

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -15,7 +15,7 @@ import shutil
 import logging
 
 # import custom python packages
-from wahoomc import file_directory_functions as fd_fct
+from wahoomc.file_directory_functions import get_tooling_win_path, read_json_file, get_folders_in_folder, get_filenames_of_jsons_in_folder
 from wahoomc.constants_functions import get_path_to_static_tile_json, translate_tags_to_keep
 
 from wahoomc.constants import USER_WAHOO_MC
@@ -60,11 +60,11 @@ def get_tile_by_one_xy_combination_from_jsons(xy_combination):
     # go through all files in all folders of the "json" directory
     file_path_jsons = os.path.join(RESOURCES_DIR, 'json')
 
-    for folder in fd_fct.get_folders_in_folder(file_path_jsons):
-        for file in fd_fct.get_filenames_of_jsons_in_folder(os.path.join(file_path_jsons, folder)):
+    for folder in get_folders_in_folder(file_path_jsons):
+        for file in get_filenames_of_jsons_in_folder(os.path.join(file_path_jsons, folder)):
 
             # get content of json in folder
-            content = fd_fct.read_json_file(
+            content = read_json_file(
                 os.path.join(file_path_jsons, folder, file + '.json'))
 
             # check tiles values against input x/y combination
@@ -105,7 +105,7 @@ class OsmMaps:
     This is a OSM data class
     """
 
-    osmosis_win_file_path = fd_fct.get_tooling_win_path(
+    osmosis_win_file_path = get_tooling_win_path(
         ['Osmosis', 'bin', 'osmosis.bat'])
 
     # Number of workers for the Osmosis read binary fast function
@@ -123,9 +123,9 @@ class OsmMaps:
             o_input_data.max_days_old, o_input_data.force_download)
 
         if 8 * struct.calcsize("P") == 32:
-            self.osmconvert_path = fd_fct.get_tooling_win_path(['osmconvert'])
+            self.osmconvert_path = get_tooling_win_path(['osmconvert'])
         else:
-            self.osmconvert_path = fd_fct.get_tooling_win_path(
+            self.osmconvert_path = get_tooling_win_path(
                 ['osmconvert64-0.8.8p'])
 
     def process_input(self, calc_border_countries):
@@ -158,7 +158,7 @@ class OsmMaps:
             else:
                 json_file_path = get_path_to_static_tile_json(
                     self.o_input_data.country)
-                self.tiles = fd_fct.read_json_file(json_file_path)
+                self.tiles = read_json_file(json_file_path)
 
             # country name is the input argument
             self.country_name = self.o_input_data.country
@@ -280,7 +280,7 @@ class OsmMaps:
 
                     log.info(
                         '+ Filtering unwanted map objects out of map of %s', key)
-                    cmd = [fd_fct.get_tooling_win_path(['osmfilter'])]
+                    cmd = [get_tooling_win_path(['osmfilter'])]
                     cmd.append(out_file_o5m)
                     cmd.append(
                         '--keep="' + translate_tags_to_keep(sys_platform=platform.system()) + '"')
@@ -291,7 +291,7 @@ class OsmMaps:
                     run_subprocess_and_log_output(
                         cmd, '! Error in OSMFilter with country: {key}')
 
-                    cmd = [fd_fct.get_tooling_win_path(['osmfilter'])]
+                    cmd = [get_tooling_win_path(['osmfilter'])]
                     cmd.append(out_file_o5m)
                     cmd.append(
                         '--keep="' + translate_tags_to_keep(
@@ -684,7 +684,7 @@ class OsmMaps:
 
                 # Windows
                 if platform.system() == "Windows":
-                    cmd = [fd_fct.get_tooling_win_path(['lzma']), 'e', out_file,
+                    cmd = [get_tooling_win_path(['lzma']), 'e', out_file,
                            out_file+'.lzma', f'-mt{threads}', '-d27', '-fb273', '-eos']
                 # Non-Windows
                 else:
@@ -746,7 +746,7 @@ class OsmMaps:
         if zip_folder:
             # Windows
             if platform.system() == "Windows":
-                cmd = [fd_fct.get_tooling_win_path(['7za']), 'a', '-tzip']
+                cmd = [get_tooling_win_path(['7za']), 'a', '-tzip']
 
                 cmd.extend(
                     [folder_name + '.zip', os.path.join(".", folder_name, "*")])

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -15,7 +15,9 @@ import shutil
 import logging
 
 # import custom python packages
-from wahoomc.file_directory_functions import get_tooling_win_path, read_json_file, get_folders_in_folder, get_filenames_of_jsons_in_folder, create_empty_directories
+from wahoomc.file_directory_functions import get_tooling_win_path, read_json_file, \
+    get_folders_in_folder, get_filenames_of_jsons_in_folder, create_empty_directories, \
+    get_tag_wahoo_xml_path, TagWahooXmlNotFoundError
 from wahoomc.constants_functions import get_path_to_static_tile_json, translate_tags_to_keep
 
 from wahoomc.constants import USER_WAHOO_MC
@@ -731,8 +733,8 @@ class OsmMaps:
                 # add path to tag-wahoo xml file
                 try:
                     cmd.append(
-                        f'tag-conf-file={fd_fct.get_tag_wahoo_xml_path(tag_wahoo_xml)}')
-                except fd_fct.TagWahooXmlNotFoundError:
+                        f'tag-conf-file={get_tag_wahoo_xml_path(tag_wahoo_xml)}')
+                except TagWahooXmlNotFoundError:
                     log.error(
                         'The tag-wahoo xml file was not found: ˚%s˚. Does the file exist and is your input correct?', tag_wahoo_xml)
                     sys.exit()

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -152,11 +152,6 @@ class OsmMaps:
 
         log.info('-' * 80)
 
-        if self.o_input_data.country and self.o_input_data.xy_coordinates:
-            log.error(
-                "! country and X/Y coordinates are given. Only one of both is allowed!")
-            sys.exit()
-
         # option 1: input a country as parameter, e.g. germany
         if self.o_input_data.country:
             log.info('# Input country: %s.', self.o_input_data.country)

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -8,8 +8,11 @@ import os
 import logging
 
 # import custom python packages
-from wahoomc import file_directory_functions as fd_fct
-from wahoomc import constants
+from wahoomc.file_directory_functions import move_content
+from wahoomc.constants import USER_WAHOO_MC
+from wahoomc.constants import USER_DL_DIR
+from wahoomc.constants import USER_MAPS_DIR
+from wahoomc.constants import USER_OUTPUT_DIR
 
 log = logging.getLogger('main-logger')
 
@@ -18,10 +21,10 @@ def initialize_work_directories():
     """
     Initialize work directories
     """
-    os.makedirs(constants.USER_WAHOO_MC, exist_ok=True)
-    os.makedirs(constants.USER_DL_DIR, exist_ok=True)
-    os.makedirs(constants.USER_MAPS_DIR, exist_ok=True)
-    os.makedirs(constants.USER_OUTPUT_DIR, exist_ok=True)
+    os.makedirs(USER_WAHOO_MC, exist_ok=True)
+    os.makedirs(USER_DL_DIR, exist_ok=True)
+    os.makedirs(USER_MAPS_DIR, exist_ok=True)
+    os.makedirs(USER_OUTPUT_DIR, exist_ok=True)
 
 
 def move_old_content_into_new_dirs():
@@ -33,5 +36,5 @@ def move_old_content_into_new_dirs():
     This coding is only valid/needed when using the cloned version or .zip version.
     If working with a installed version via PyPI, nothing will be done because folders to copy do not exist
     """
-    fd_fct.move_content('wahooMapsCreator_download', constants.USER_DL_DIR)
-    fd_fct.move_content('wahooMapsCreator_output', constants.USER_OUTPUT_DIR)
+    move_content('wahooMapsCreator_download', USER_DL_DIR)
+    move_content('wahooMapsCreator_output', USER_OUTPUT_DIR)


### PR DESCRIPTION
## This PR…

- breaks osm_maps_functions.py into two classes: one for the data and one for processing maps
- refactors a lot of stuff around: calc_border_countries, input checks, proce_processing evaluation
- refactors the imports to "single import" instead of importing the whole file

## Considerations and implementations

A lot of lines change with this PR, the unittests rise from 45 to 47.
In the long run this is a useful refactoring which makes understanding easier.

## How to test

1. do everything you do with wahooMapsCreator

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [ ] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
