### PR TITLE
[FEAT] Make logging uniformly and include variables into the message correctly

### DIFF
--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -38,7 +38,7 @@ def download_file(target_filepath, url, is_zip):
     """
     logging_filename = target_filepath.split(os.sep)[-1]
     log.info('-' * 80)
-    log.info('+ Downloading %s file', logging_filename)
+    log.info('# Downloading %s file', logging_filename)
     if is_zip:
         # build target-filepath based on last element of URL
         last_part = url.rsplit('/', 1)[-1]
@@ -124,7 +124,7 @@ class Downloader:
 
         if self.check_file(LAND_POLYGONS_PATH) is True or \
                 self.force_download is True:
-            log.info('# Need to download land polygons file')
+            log.info('+ Need to download land polygons file')
             self.need_to_dl.append('land_polygons')
 
     def download_files_if_needed(self):

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -576,8 +576,6 @@ class OsmMaps:
                     run_subprocess_and_log_output(
                         cmd, '! Error in Osmosis with country: {country}. macOS/out_file_names')
 
-                    log.info(val['filtered_file'])
-
             tile_count += 1
 
         log.info('+ Split filtered country files to tiles: OK')

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -337,7 +337,7 @@ class OsmMaps:
                     cmd.append('-o='+out_file_o5m)
 
                     run_subprocess_and_log_output(
-                        cmd, '! Error in OSMConvert with country: {key}')
+                        cmd, f'! Error in OSMConvert with country: {key}')
                 else:
                     log.info('+ Map of %s already in o5m format', key)
 
@@ -354,7 +354,7 @@ class OsmMaps:
                 cmd.append('-o=' + out_file_o5m_filtered_win)
 
                 run_subprocess_and_log_output(
-                    cmd, '! Error in OSMFilter with country: {key}')
+                    cmd, f'! Error in OSMFilter with country: {key}')
 
                 cmd = [get_tooling_win_path(['osmfilter'])]
                 cmd.append(out_file_o5m)
@@ -367,7 +367,7 @@ class OsmMaps:
                 cmd.append('-o=' + out_file_o5m_filtered_names_win)
 
                 run_subprocess_and_log_output(
-                    cmd, '! Error in OSMFilter with country: {key}')
+                    cmd, f'! Error in OSMFilter with country: {key}')
 
                 val['filtered_file'] = out_file_o5m_filtered_win
                 val['filtered_file_names'] = out_file_o5m_filtered_names_win
@@ -389,7 +389,7 @@ class OsmMaps:
                 cmd.append('--overwrite')
 
                 run_subprocess_and_log_output(
-                    cmd, '! Error in Osmium with country: {key}')
+                    cmd, f'! Error in Osmium with country: {key}')
 
                 cmd = ['osmium', 'tags-filter', '--remove-tags']
                 cmd.append(val['map_file'])
@@ -399,7 +399,7 @@ class OsmMaps:
                 cmd.append('--overwrite')
 
                 run_subprocess_and_log_output(
-                    cmd, '! Error in Osmium with country: {key}')
+                    cmd, f'! Error in Osmium with country: {key}')
 
                 val['filtered_file'] = out_file_pbf_filtered_mac
                 val['filtered_file_names'] = out_file_pbf_filtered_names_mac

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -412,7 +412,7 @@ class OsmMaps:
         """
 
         log.info('-' * 80)
-        log.info('# Generate land')
+        log.info('# Generate land for each coordinate')
 
         tile_count = 1
         for tile in self.o_osm_data.tiles:
@@ -424,7 +424,7 @@ class OsmMaps:
             # create land.dbf, land.prj, land.shp, land.shx
             if not os.path.isfile(land_file) or self.o_osm_data.force_processing is True:
                 log.info(
-                    '+ Generate land %s of %s for Coordinates: %s,%s', tile_count, len(self.o_osm_data.tiles), tile["x"], tile["y"])
+                    '+ Coordinates: %s,%s. (%s of %s)', tile["x"], tile["y"], tile_count, len(self.o_osm_data.tiles))
                 cmd = ['ogr2ogr', '-overwrite', '-skipfailures']
                 # Try to prevent getting outside of the +/-180 and +/- 90 degrees borders. Normally the +/- 0.1 are there to prevent white lines at border borders.
                 if tile["x"] == 255 or tile["y"] == 255 or tile["x"] == 0 or tile["y"] == 0:
@@ -459,7 +459,7 @@ class OsmMaps:
                     cmd, f'! Error creating land.osm for tile: {tile["x"]},{tile["y"]}')
             tile_count += 1
 
-        log.info('+ Generate land: OK')
+        log.info('+ Generate land for each coordinate: OK')
 
     def generate_sea(self):
         """
@@ -467,7 +467,7 @@ class OsmMaps:
         """
 
         log.info('-' * 80)
-        log.info('# Generate sea')
+        log.info('# Generate sea for each coordinate')
 
         tile_count = 1
         for tile in self.o_osm_data.tiles:
@@ -475,7 +475,7 @@ class OsmMaps:
                                         f'{tile["x"]}', f'{tile["y"]}', 'sea.osm')
             if not os.path.isfile(out_file_sea) or self.o_osm_data.force_processing is True:
                 log.info(
-                    '+ Generate sea %s of %s for Coordinates: %s,%s', tile_count, len(self.o_osm_data.tiles), tile["x"], tile["y"])
+                    '+ Coordinates: %s,%s. (%s of %s)', tile["x"], tile["y"], tile_count, len(self.o_osm_data.tiles))
                 with open(os.path.join(RESOURCES_DIR, 'sea.osm'), encoding="utf-8") as sea_file:
                     sea_data = sea_file.read()
 
@@ -503,7 +503,7 @@ class OsmMaps:
                         output_file.write(sea_data)
             tile_count += 1
 
-        log.info('+ Generate sea: OK')
+        log.info('+ Generate sea for each coordinate: OK')
 
     def split_filtered_country_files_to_tiles(self):
         """
@@ -519,7 +519,7 @@ class OsmMaps:
                 if country not in tile['countries']:
                     continue
                 log.info(
-                    '+ Splitting tile %s of %s for Coordinates: %s,%s from map of %s', tile_count, len(self.o_osm_data.tiles), tile["x"], tile["y"], country)
+                    '+ Coordinates: %s,%s / %s (%s of %s)', tile["x"], tile["y"], country, tile_count, len(self.o_osm_data.tiles))
                 out_file = os.path.join(USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}', f'split-{country}.osm.pbf')
                 out_file_names = os.path.join(USER_OUTPUT_DIR,
@@ -700,7 +700,7 @@ class OsmMaps:
         """
 
         log.info('-' * 80)
-        log.info('# Creating .map files')
+        log.info('# Creating .map files for tiles')
 
         # Number of threads to use in the mapwriter plug-in
         threads = multiprocessing.cpu_count() - 1
@@ -710,7 +710,8 @@ class OsmMaps:
         tile_count = 1
         for tile in self.o_osm_data.tiles:
             log.info(
-                '+ Creating map file for tile %s of %s for Coordinates: %s,%s', tile_count, len(self.o_osm_data.tiles), tile["x"], tile["y"])
+                '+ Coordinates: %s,%s (%s of %s)', tile["x"], tile["y"], tile_count, len(self.o_osm_data.tiles))
+
             out_file_map = os.path.join(USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}.map')
 
@@ -765,7 +766,7 @@ class OsmMaps:
 
             tile_count += 1
 
-        log.info('+ Creating .map files: OK')
+        log.info('+ Creating .map files for tiles: OK')
 
     def make_and_zip_files(self, extension, zip_folder):
         """


### PR DESCRIPTION
## This PR…

- Make logging uniformly and include variables into the message `{key}` ones

## How to test

1. run `python -m wahoomc cli -co malta` and check if the logging to terminal is OK

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
