### PR TITLE
[DEV] install: introduce config file .config.json // store python module version

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -6,8 +6,10 @@ import platform
 import os
 
 # import custom python packages
-from wahoomc.setup_functions import is_program_installed, is_map_writer_plugin_installed
+from wahoomc.setup_functions import is_program_installed, is_map_writer_plugin_installed, read_version_last_run
 from wahoomc.constants_functions import get_tooling_win_path
+from wahoomc.constants import USER_WAHOO_MC
+from wahoomc.file_directory_functions import write_json_file_generic
 
 
 class TestSetup(unittest.TestCase):
@@ -47,10 +49,46 @@ class TestSetup(unittest.TestCase):
         """
         tests, if a given program is installed
         """
-
         result = is_program_installed(program)
 
         self.assertTrue(result)
+
+
+class TestConfigFile(unittest.TestCase):
+    """
+    tests for the config .json file in the "wahooMapsCreatorData" directory
+    """
+
+    config_file_path = os.path.join(USER_WAHOO_MC, ".config.json")
+
+    def test_version_if_no_config_file_exists(self):
+        """
+        tests, if the return value is None if the config file is deleted
+        """
+        if os.path.exists(self.config_file_path):
+            os.remove(self.config_file_path)
+
+        self.assertEqual(None, read_version_last_run())
+
+    def test_version_if_written_eq(self):
+        """
+        tests, if return version is the one saved
+        """
+        # write dictionary to config file
+        write_json_file_generic(self.config_file_path, {
+                                "version_last_run": '2.0.2'})
+
+        self.assertEqual('2.0.2', read_version_last_run())
+
+    def test_version_if_written_neq(self):
+        """
+        tests, if the comparison of the returned version_last_run is OK
+        """
+        # write dictionary to config file
+        write_json_file_generic(self.config_file_path, {
+                                "version_last_run": '2.0.3'})
+
+        self.assertNotEqual('2.0.2', read_version_last_run())
 
 
 if __name__ == '__main__':

--- a/wahoomc/constants.py
+++ b/wahoomc/constants.py
@@ -20,6 +20,7 @@ WAHOO_MC_DIR = os.path.dirname(__file__)
 RESOURCES_DIR = os.path.join(WAHOO_MC_DIR, 'resources')
 TOOLING_WIN_DIR = os.path.join(WAHOO_MC_DIR, 'tooling_win')
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+VERSION = '2.0.2'
 
 Translate_Country = {
     'alaska':                           'united_states_of_america',

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -13,7 +13,8 @@ import logging
 
 # import custom python packages
 from wahoomc.file_directory_functions import download_url_to_file, unzip
-from wahoomc.constants_functions import translate_country_input_to_geofabrik, get_geofabrik_region_of_country
+from wahoomc.constants_functions import translate_country_input_to_geofabrik, \
+    get_geofabrik_region_of_country
 
 from wahoomc.constants import USER_DL_DIR
 from wahoomc.constants import USER_MAPS_DIR

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -159,3 +159,48 @@ def get_filenames_of_jsons_in_folder(folder):
             json_files.extend([filename])
 
     return json_files
+
+
+def read_json(json_file_path):
+    """
+    read given json file
+    """
+    with open(json_file_path, encoding="utf-8") as json_file:
+        json_content = json.load(json_file)
+        json_file.close()
+    if json_content == '':
+        log.error('! Json file could not be opened.')
+        sys.exit()
+
+    log.debug(
+        '+ Use json file %s with %s tiles', json_file.name, len(json_content))
+    log.debug('+ Read json file: OK')
+
+    return json_content
+
+
+def write_json(json_file_path, json_content):
+    """
+    writes content to .json file
+    """
+    # Serializing json
+    json_object = json.dumps(json_content, indent=4)
+
+    # Writing to file
+    with open(json_file_path, "w", encoding="utf-8") as outfile:
+        outfile.write(json_object)
+        outfile.close()
+
+
+def delete_o5m_pbf_files_in_folder(folder):
+    """
+    delete .o5m and .pbf files of given folder
+    """
+    onlyfiles = [f for f in os.listdir(folder) if isfile(join(folder, f))]
+
+    for file in onlyfiles:
+        if file.endswith('.o5m') or file.endswith('.pbf'):
+            try:
+                os.remove(os.path.join(folder, file))
+            except OSError:
+                pass

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -103,6 +103,30 @@ def read_json_file(json_file_path):
     return tiles_from_json
 
 
+def read_json_file_generic(json_file_path):
+    """
+    reads content of given .json file
+    """
+    with open(json_file_path, encoding="utf-8") as json_file:
+        json_content = json.load(json_file)
+        json_file.close()
+
+    return json_content
+
+
+def write_json_file_generic(json_file_path, json_content):
+    """
+    writes content to .json file
+    """
+    # Serializing json
+    json_content = json.dumps(json_content, indent=4)
+
+    # Writing to file
+    with open(json_file_path, "w", encoding="utf-8") as json_file:
+        json_file.write(json_content)
+        json_file.close()
+
+
 def download_url_to_file(url, map_file_path):
     """
     download the content of a ULR to file
@@ -159,37 +183,6 @@ def get_filenames_of_jsons_in_folder(folder):
             json_files.extend([filename])
 
     return json_files
-
-
-def read_json(json_file_path):
-    """
-    read given json file
-    """
-    with open(json_file_path, encoding="utf-8") as json_file:
-        json_content = json.load(json_file)
-        json_file.close()
-    if json_content == '':
-        log.error('! Json file could not be opened.')
-        sys.exit()
-
-    log.debug(
-        '+ Use json file %s with %s tiles', json_file.name, len(json_content))
-    log.debug('+ Read json file: OK')
-
-    return json_content
-
-
-def write_json(json_file_path, json_content):
-    """
-    writes content to .json file
-    """
-    # Serializing json
-    json_object = json.dumps(json_content, indent=4)
-
-    # Writing to file
-    with open(json_file_path, "w", encoding="utf-8") as outfile:
-        outfile.write(json_object)
-        outfile.close()
 
 
 def delete_o5m_pbf_files_in_folder(folder):

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -8,10 +8,10 @@ import logging
 
 # import custom python packages
 from wahoomc.input import process_call_of_the_tool
-from wahoomc.setup_functions import initialize_work_directories
-from wahoomc.setup_functions import check_installation_of_required_programs
-from wahoomc.setup_functions import write_config_file
-from wahoomc.setup_functions import adjustments_due_to_breaking_changes
+from wahoomc.setup_functions import initialize_work_directories, \
+    check_installation_of_required_programs, write_config_file, \
+    adjustments_due_to_breaking_changes
+
 from wahoomc.osm_maps_functions import OsmMaps
 from wahoomc.osm_maps_functions import OsmData
 

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -11,6 +11,8 @@ from wahoomc.input import process_call_of_the_tool
 from wahoomc.setup_functions import initialize_work_directories
 from wahoomc.setup_functions import move_old_content_into_new_dirs
 from wahoomc.setup_functions import check_installation_of_required_programs
+from wahoomc.setup_functions import write_config_file
+from wahoomc.setup_functions import do_stuff_based_on_versioning
 from wahoomc.osm_maps_functions import OsmMaps
 from wahoomc.osm_maps_functions import OsmData
 
@@ -36,6 +38,7 @@ def run():
     # Is there something to do?
     o_input_data.is_required_input_given_or_exit(issue_message=True)
 
+    do_stuff_based_on_versioning()
     initialize_work_directories()
     move_old_content_into_new_dirs()
 
@@ -75,3 +78,6 @@ def run():
     # Make Cruiser map files zip file
     if o_input_data.save_cruiser is True:
         o_osm_maps.make_and_zip_files('.map', o_input_data.zip_folder)
+
+    # run was successful --> write config file
+    write_config_file()

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -11,7 +11,7 @@ from wahoomc.input import process_call_of_the_tool
 from wahoomc.setup_functions import initialize_work_directories
 from wahoomc.setup_functions import check_installation_of_required_programs
 from wahoomc.setup_functions import write_config_file
-from wahoomc.setup_functions import do_stuff_based_on_versioning
+from wahoomc.setup_functions import adjustments_due_to_breaking_changes
 from wahoomc.osm_maps_functions import OsmMaps
 from wahoomc.osm_maps_functions import OsmData
 
@@ -37,7 +37,7 @@ def run():
     # Is there something to do?
     o_input_data.is_required_input_given_or_exit(issue_message=True)
 
-    do_stuff_based_on_versioning()
+    adjustments_due_to_breaking_changes()
     initialize_work_directories()
 
     o_osm_data = OsmData()

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -9,7 +9,6 @@ import logging
 # import custom python packages
 from wahoomc.input import process_call_of_the_tool
 from wahoomc.setup_functions import initialize_work_directories
-from wahoomc.setup_functions import move_old_content_into_new_dirs
 from wahoomc.setup_functions import check_installation_of_required_programs
 from wahoomc.setup_functions import write_config_file
 from wahoomc.setup_functions import do_stuff_based_on_versioning
@@ -40,7 +39,6 @@ def run():
 
     do_stuff_based_on_versioning()
     initialize_work_directories()
-    move_old_content_into_new_dirs()
 
     o_osm_data = OsmData()
     # Check for not existing or expired files. Mark for download, if dl is needed

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -48,6 +48,10 @@ def move_old_content_into_new_dirs():
     This coding is only valid/needed when using the cloned version or .zip version.
     If working with a installed version via PyPI, nothing will be done because folders to copy do not exist
     """
+    # create directories first because initialize_work_directories is now called later
+    os.makedirs(USER_DL_DIR, exist_ok=True)
+    os.makedirs(USER_OUTPUT_DIR, exist_ok=True)
+
     move_content('wahooMapsCreator_download', USER_DL_DIR)
     move_content('wahooMapsCreator_output', USER_OUTPUT_DIR)
 
@@ -65,6 +69,12 @@ def do_stuff_based_on_versioning():
         log.info(
             'Last run was with version %s, deleting %s directory due to breaking changes.', version_last_run, USER_OUTPUT_DIR)
         delete_o5m_pbf_files_in_folder(USER_OUTPUT_DIR)
+
+    if version_last_run is None or \
+            pkg_resources.parse_version(version_last_run) < pkg_resources.parse_version('1.1.0'):
+        log.info(
+            'Last run was with version %s, moving content to new directories due to breaking changes.', version_last_run)
+        move_old_content_into_new_dirs()
 
 
 def check_installation_of_required_programs():

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -56,7 +56,7 @@ def move_old_content_into_new_dirs():
     move_content('wahooMapsCreator_output', USER_OUTPUT_DIR)
 
 
-def do_stuff_based_on_versioning():
+def adjustments_due_to_breaking_changes():
     """
     copy files from download- and output- directory of earlier version to the new folders
     """

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -65,13 +65,13 @@ def adjustments_due_to_breaking_changes():
     # file-names of filteres country files were uniformed in #153.
     # due to that old files are sometimes no longer accessed and the whole _.
     if version_last_run is None or \
-            pkg_resources.parse_version(version_last_run) > pkg_resources.parse_version('2.0.2'):
+            pkg_resources.parse_version(VERSION) > pkg_resources.parse_version('2.0.2'):
         log.info(
-            'Last run was with version %s, deleting %s directory due to breaking changes.', version_last_run, USER_OUTPUT_DIR)
+            'Last run was with version %s, deleting files of %s directory due to breaking changes.', version_last_run, USER_OUTPUT_DIR)
         delete_o5m_pbf_files_in_folder(USER_OUTPUT_DIR)
 
     if version_last_run is None or \
-            pkg_resources.parse_version(version_last_run) < pkg_resources.parse_version('1.1.0'):
+            pkg_resources.parse_version(VERSION) < pkg_resources.parse_version('1.1.0'):
         log.info(
             'Last run was with version %s, moving content to new directories due to breaking changes.', version_last_run)
         move_old_content_into_new_dirs()

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -13,8 +13,10 @@ import sys
 import pkg_resources
 
 # import custom python packages
-from wahoomc.file_directory_functions import move_content, write_json_file_generic, read_json_file_generic, delete_o5m_pbf_files_in_folder
+from wahoomc.file_directory_functions import move_content, write_json_file_generic, \
+    read_json_file_generic, delete_o5m_pbf_files_in_folder
 from wahoomc.constants_functions import get_tooling_win_path
+
 from wahoomc.constants import USER_WAHOO_MC
 from wahoomc.constants import USER_DL_DIR
 from wahoomc.constants import USER_MAPS_DIR


### PR DESCRIPTION
## This PR…

- introduces `~/wahooMapsCreatorData/.config.json` file to store values about the last wahooMapsCreator run such as the version of the python module

## Considerations and implementations

Having this in place we can implement release-based changes such as remaning of files, directories. Moreover we can speed up processing by skipping things which are done once per each version (if there is anything, might be more interesting per country and version).

## How to test

1. run wahoomc as normal and check output

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
