### PR TITLE
[FEAT] Filter country file if new new tags are being used // introduce country config file .config.json

### DIFF
--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -9,6 +9,7 @@ import unittest
 # sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from wahoomc.osm_maps_functions import OsmData
+from wahoomc.osm_maps_functions import OsmMaps
 from wahoomc.osm_maps_functions import get_tile_by_one_xy_combination_from_jsons
 from wahoomc.osm_maps_functions import get_xy_coordinates_from_input
 from wahoomc.osm_maps_functions import TileNotFoundError
@@ -350,6 +351,35 @@ class TestStaticJsons(unittest.TestCase):
         for country in constants.unitedstates:
             self.calculate_path_to_static_tile_json(
                 country, os.path.join("united_states", country))
+
+
+class TestConfigFile(unittest.TestCase):
+    """
+    tests for the config .json file in the "wahooMapsCreatorData/_tiles/{country}" directory
+    """
+
+    def test_version_and_tags_of_country_config_file(self):
+        """
+        tests, if the return value of version is OK and if the tags are the same
+        """
+
+        o_input_data = InputData()
+        o_input_data.country = 'malta'
+
+        o_osm_data = OsmData()
+        o_osm_data.process_input_of_the_tool(o_input_data)
+
+        o_osm_maps = OsmMaps(o_osm_data)
+
+        o_osm_maps.write_country_config_file(o_input_data.country)
+
+        self.assertTrue(
+            o_osm_maps.tags_are_identical_to_last_run(o_input_data.country))
+
+        country_config = fd_fct.read_json_file(os.path.join(
+            constants.USER_OUTPUT_DIR, o_input_data.country, ".config.json"))
+
+        self.assertEqual(constants.VERSION, country_config["version_last_run"])
 
 
 if __name__ == '__main__':

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -70,15 +70,18 @@ def move_content(src_folder_name, dst_path):
         shutil.rmtree(source_dir)
 
 
-def create_empty_directories(parent_dir, tiles_from_json):
+def create_empty_directories(parent_dir, tiles_from_json, border_countries):
     """
-    create empty directory for the files
+    create empty directories for each tile and each country
     """
     for tile in tiles_from_json:
         outdir = os.path.join(parent_dir,
                               f'{tile["x"]}', f'{tile["y"]}')
-        if not os.path.isdir(outdir):
-            os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
+
+    for country in border_countries:
+        outdir = os.path.join(parent_dir, country)
+        os.makedirs(outdir, exist_ok=True)
 
 
 def read_json_file(json_file_path):

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -317,14 +317,16 @@ class OsmMaps:
         log.info('# Filter tags from country osm.pbf files')
 
         for key, val in self.o_osm_data.border_countries.items():
-            out_file_o5m_filtered_win = os.path.join(USER_OUTPUT_DIR,
-                                                     f'outFileFiltered-{key}.o5m')
-            out_file_o5m_filtered_names_win = os.path.join(USER_OUTPUT_DIR,
-                                                           f'outFileFiltered-{key}-Names.o5m')
+            out_file_o5m_filtered_win = os.path.join(USER_OUTPUT_DIR, key,
+                                                     'filtered.o5m')
+            out_file_o5m_filtered_names_win = os.path.join(USER_OUTPUT_DIR, key,
+                                                           'filtered_names.o5m')
+            os.makedirs(os.path.join(USER_OUTPUT_DIR, key), exist_ok=True)
+
             # Windows
             if platform.system() == "Windows":
-                out_file_o5m = os.path.join(USER_OUTPUT_DIR,
-                                            f'outFile-{key}.o5m')
+                out_file_o5m = os.path.join(
+                    USER_OUTPUT_DIR, key, 'outFile.o5m')
                 # only create o5m file if not there already or force processing (no user input possible)
                 # --> speeds up processing if one only wants to test tags / POIs
                 if not os.path.isfile(out_file_o5m) or self.o_osm_data.force_processing is True:

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -16,7 +16,7 @@ import logging
 
 # import custom python packages
 from wahoomc.file_directory_functions import read_json_file, \
-    get_folders_in_folder, get_filenames_of_jsons_in_folder, create_empty_directories
+    get_folders_in_folder, get_filenames_of_jsons_in_folder, create_empty_directories, write_json_file_generic
 from wahoomc.constants_functions import get_path_to_static_tile_json, translate_tags_to_keep, \
     get_tooling_win_path, get_tag_wahoo_xml_path, TagWahooXmlNotFoundError
 
@@ -24,6 +24,7 @@ from wahoomc.constants import USER_WAHOO_MC
 from wahoomc.constants import USER_OUTPUT_DIR
 from wahoomc.constants import RESOURCES_DIR
 from wahoomc.constants import LAND_POLYGONS_PATH
+from wahoomc.constants import VERSION
 
 from wahoomc.downloader import Downloader
 from wahoomc.geofabrik import Geofabrik
@@ -322,6 +323,7 @@ class OsmMaps:
             out_file_o5m_filtered_names_win = os.path.join(USER_OUTPUT_DIR, key,
                                                            'filtered_names.o5m')
             os.makedirs(os.path.join(USER_OUTPUT_DIR, key), exist_ok=True)
+            self.write_country_config_file(os.path.join(USER_OUTPUT_DIR, key))
 
             # Windows
             if platform.system() == "Windows":
@@ -852,3 +854,15 @@ class OsmMaps:
             log.error(
                 '! Error copying %s files for country %s: %s', extension, self.o_osm_data.country_name, exception)
             sys.exit()
+
+    def write_country_config_file(self, config_dir):
+        """
+        Write country config file of _tiles/{country} directory
+        """
+        # Data to be written
+        configuration = {
+            "version_last_run": VERSION
+        }
+
+        write_json_file_generic(os.path.join(
+            config_dir, ".config.json"), configuration)

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -422,7 +422,7 @@ class OsmMaps:
                 val['filtered_file_names'] = out_file_pbf_filtered_names_mac
 
             # write config file for country
-            self.write_country_config_file(country_dir)
+            self.write_country_config_file(key)
 
         log.info('+ Filter tags from country osm.pbf files: OK')
 
@@ -871,18 +871,18 @@ class OsmMaps:
                 '! Error copying %s files for country %s: %s', extension, self.o_osm_data.country_name, exception)
             sys.exit()
 
-    def write_country_config_file(self, config_dir):
+    def write_country_config_file(self, country):
         """
-        Write country config file of _tiles/{country} directory
+        Write country config file into _tiles/{country} directory
         """
         # Data to be written
         configuration = {
-            "version_last_run": VERSION
+            "version_last_run": VERSION,
+            "tags_last_run": translate_tags_to_keep()
         }
-        configuration["tags_last_run"] = translate_tags_to_keep()
 
         write_json_file_generic(os.path.join(
-            config_dir, ".config.json"), configuration)
+            USER_OUTPUT_DIR, country, ".config.json"), configuration)
 
     def compare_tags_to_last_run(self, country):
         """

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -320,8 +320,6 @@ class OsmMaps:
         for key, val in self.o_osm_data.border_countries.items():
             # evaluate contry directory, create if not exists
             country_dir = os.path.join(USER_OUTPUT_DIR, key)
-            # check if filtered files were created with the same tags already
-            tags_are_different = self.compare_tags_to_last_run(key)
 
             # set names for filtered files for WIN, later on add ".pbf" for macOS/Linux
             out_file_o5m_filtered_win = os.path.join(country_dir,
@@ -353,7 +351,7 @@ class OsmMaps:
                 # - force processing is set (this is also when new map files were dowwnloaded)
                 # - the defined TAGS_TO_KEEP_UNIVERSAL constants have changed are changed (user input or new release)
                 if not os.path.isfile(out_file_o5m_filtered_win) or not os.path.isfile(out_file_o5m_filtered_names_win) \
-                        or self.o_osm_data.force_processing is True or tags_are_different:
+                        or self.o_osm_data.force_processing is True or self.tags_are_identical_to_last_run(key) is False:
                     log.info(
                         '+ Filtering unwanted map objects out of map of %s', key)
                     cmd = [get_tooling_win_path(['osmfilter'])]
@@ -393,7 +391,7 @@ class OsmMaps:
                 # - force processing is set (this is also when new map files were dowwnloaded)
                 # - the defined TAGS_TO_KEEP_UNIVERSAL constants have changed are changed (user input or new release)
                 if not os.path.isfile(out_file_pbf_filtered_mac) or not os.path.isfile(out_file_pbf_filtered_names_mac) \
-                        or self.o_osm_data.force_processing is True or tags_are_different:
+                        or self.o_osm_data.force_processing is True or self.tags_are_identical_to_last_run(key) is False:
                     log.info(
                         '+ Filtering unwanted map objects out of map of %s', key)
 
@@ -884,18 +882,18 @@ class OsmMaps:
         write_json_file_generic(os.path.join(
             USER_OUTPUT_DIR, country, ".config.json"), configuration)
 
-    def compare_tags_to_last_run(self, country):
+    def tags_are_identical_to_last_run(self, country):
         """
-        conpare tags of this run with used tags from last run stored in _tiles/{country} directory
+        compare tags of this run with used tags from last run stored in _tiles/{country} directory
         """
-        tags_are_different = False
+        tags_are_identical = True
 
         try:
             country_config = read_json_file(os.path.join(
                 USER_OUTPUT_DIR, country, ".config.json"))
             if not country_config["tags_last_run"] == translate_tags_to_keep(sys_platform=platform.system()):
-                tags_are_different = True
+                tags_are_identical = False
         except (FileNotFoundError, KeyError):
-            tags_are_different = True
+            tags_are_identical = False
 
-        return tags_are_different
+        return tags_are_identical

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -318,17 +318,21 @@ class OsmMaps:
         log.info('# Filter tags from country osm.pbf files')
 
         for key, val in self.o_osm_data.border_countries.items():
-            out_file_o5m_filtered_win = os.path.join(USER_OUTPUT_DIR, key,
-                                                     'filtered.o5m')
-            out_file_o5m_filtered_names_win = os.path.join(USER_OUTPUT_DIR, key,
-                                                           'filtered_names.o5m')
-            os.makedirs(os.path.join(USER_OUTPUT_DIR, key), exist_ok=True)
+            # evaluate contry directory, create if not exists
+            country_dir = os.path.join(USER_OUTPUT_DIR, key)
+            os.makedirs(country_dir, exist_ok=True)
+            # check if filtered files were created with the same tags already
             tags_are_different = self.compare_tags_to_last_run(key)
+
+            # set names for filtered files for WIN, later on add ".pbf" for macOS/Linux
+            out_file_o5m_filtered_win = os.path.join(country_dir,
+                                                     'filtered.o5m')
+            out_file_o5m_filtered_names_win = os.path.join(country_dir,
+                                                           'filtered_names.o5m')
 
             # Windows
             if platform.system() == "Windows":
-                out_file_o5m = os.path.join(
-                    USER_OUTPUT_DIR, key, 'outFile.o5m')
+                out_file_o5m = os.path.join(country_dir, 'outFile.o5m')
                 # only create o5m file if not there already or force processing (no user input possible)
                 # --> speeds up processing if one only wants to test tags / POIs
                 if not os.path.isfile(out_file_o5m) or self.o_osm_data.force_processing is True:
@@ -391,7 +395,6 @@ class OsmMaps:
                 # - the defined TAGS_TO_KEEP_UNIVERSAL constants have changed are changed (user input or new release)
                 if not os.path.isfile(out_file_pbf_filtered_mac) or not os.path.isfile(out_file_pbf_filtered_names_mac) \
                         or self.o_osm_data.force_processing is True or tags_are_different:
-
                     log.info(
                         '+ Filtering unwanted map objects out of map of %s', key)
 
@@ -420,7 +423,7 @@ class OsmMaps:
                 val['filtered_file_names'] = out_file_pbf_filtered_names_mac
 
             # write config file for country
-            self.write_country_config_file(os.path.join(USER_OUTPUT_DIR, key))
+            self.write_country_config_file(country_dir)
 
         log.info('+ Filter tags from country osm.pbf files: OK')
 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -307,7 +307,7 @@ class OsmMaps:
                 ['osmconvert64-0.8.8p'])
 
         create_empty_directories(
-            USER_OUTPUT_DIR, self.o_osm_data.tiles)
+            USER_OUTPUT_DIR, self.o_osm_data.tiles, self.o_osm_data.border_countries)
 
     def filter_tags_from_country_osm_pbf_files(self):  # pylint: disable=too-many-statements
         """
@@ -320,7 +320,6 @@ class OsmMaps:
         for key, val in self.o_osm_data.border_countries.items():
             # evaluate contry directory, create if not exists
             country_dir = os.path.join(USER_OUTPUT_DIR, key)
-            os.makedirs(country_dir, exist_ok=True)
             # check if filtered files were created with the same tags already
             tags_are_different = self.compare_tags_to_last_run(key)
 


### PR DESCRIPTION
## This PR…

- introduces `~/wahooMapsCreatorData/_tiles/{country}/.config.json` file to store values about the last country-processing using wahooMapsCreator run such as the version of the python module and used tags to filter, ...

## Considerations and implementations

Having this in place we can implement release-based changes such as remaning of files, directories. Moreover we can speed up processing by skipping things which are done once per each version (if there is anything, might be more interesting per country and version).

## How to test

1. run wahoomc as normal and check output

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
