### PR TITLE
[BREAKING] Upgrade required Python version to 3.11, upgrade packages GDAL to 3.6 and autopep8 to 2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/conda_env/gdal-dev.yml
+++ b/conda_env/gdal-dev.yml
@@ -8,7 +8,7 @@ dependencies:
   - pylint=2.15.*
   - geojson=2.5.*
   - shapely=1.8.*
-  - autopep8=1.7.*
+  - autopep8=2.0.*
   - mock
   - twine
   - pip

--- a/conda_env/gdal-dev.yml
+++ b/conda_env/gdal-dev.yml
@@ -2,7 +2,7 @@ name: gdal-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.11
   - gdal=3.4.*
   - requests=2.28.*
   - pylint=2.15.*

--- a/conda_env/gdal-dev.yml
+++ b/conda_env/gdal-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - gdal=3.4.*
+  - gdal=3.6.*
   - requests=2.28.*
   - pylint=2.15.*
   - geojson=2.5.*

--- a/conda_env/gdal-user.yml
+++ b/conda_env/gdal-user.yml
@@ -2,7 +2,7 @@ name: gdal-user
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.11
   - geojson=2.5.*
   - gdal=3.4.*
   - pip

--- a/conda_env/gdal-user.yml
+++ b/conda_env/gdal-user.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.11
   - geojson=2.5.*
-  - gdal=3.4.*
+  - gdal=3.6.*
   - pip
   - pip:
       - wahoomc==3.2.0

--- a/docs/QUICKSTART_ANACONDA.md
+++ b/docs/QUICKSTART_ANACONDA.md
@@ -86,7 +86,7 @@ mkdir -p .openstreetmap/osmosis/plugins
 1. Open terminal (macOS/Linux) or **Anaconda Prompt** (Windows, via Startmenu)
 2. Create a new Anaconda environment with needed packages
 ```
-conda create -n gdal-user python=3.7 geojson=2.5 gdal=3.4 pip --channel conda-forge --override-channels
+conda create -n gdal-user python=3.11 geojson=2.5 gdal=3.4 pip --channel conda-forge --override-channels
 ```
 3. activate Anaconda environment with the command printed out (this needs to be done each time you want to use wahooMapsCreator maps)
 ```

--- a/docs/QUICKSTART_ANACONDA.md
+++ b/docs/QUICKSTART_ANACONDA.md
@@ -86,7 +86,7 @@ mkdir -p .openstreetmap/osmosis/plugins
 1. Open terminal (macOS/Linux) or **Anaconda Prompt** (Windows, via Startmenu)
 2. Create a new Anaconda environment with needed packages
 ```
-conda create -n gdal-user python=3.11 geojson=2.5 gdal=3.4 pip --channel conda-forge --override-channels
+conda create -n gdal-user python=3.11 geojson=2.5 gdal=3.6 pip --channel conda-forge --override-channels
 ```
 3. activate Anaconda environment with the command printed out (this needs to be done each time you want to use wahooMapsCreator maps)
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 
 [options]
 packages = wahoomc, wahoomc.init
-python_requires = >=3.7
+python_requires = >=3.11
 install_requires =
     requests==2.28.*
     shapely==1.8.*


### PR DESCRIPTION
## This PR…

- makes changes in all relevant files to require Python version 3.11
- updates GDAL to 3.6, 3.4 wil not work with Python 3.11
- updated dev dependency autopep8 to 2.0

## Considerations and implementations

The former Python version 3.7 reaches end of live on the 27.06.2023 (https://devguide.python.org/versions/).

### Upgrade existing Anaconda environment
Remove existing environment:
`conda env remove -n gdal-user`
Create new environment and install wahoomc:
```
conda create -n gdal-user python=3.11 geojson=2.5 gdal=3.6 pip --channel conda-forge --override-channels
conda activate gdal-user
pip install wahoomc
```

After release v4.0.0 has been merged, this will also be taken over to the [docs](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/QUICKSTART_ANACONDA.md#create-anaconda-environment):

## How to test

1. create new dev or user environment
2. create your country / tile as always and check content

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
