### PR TITLE
[BUGFIX] Raise max. memory for Osmosis in Windows to 3GB

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 3.1.0
+version = 3.1.1a0
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/wahoomc/tooling_win/Osmosis/bin/osmosis.bat
+++ b/wahoomc/tooling_win/Osmosis/bin/osmosis.bat
@@ -1,5 +1,8 @@
 @ECHO OFF
 
+REM # set the max. memory to be used to 3GB
+set JAVACMD_OPTIONS=""-server -Xmx3G""
+
 REM This is an equivalent Windows batch file to complement the unix shell script
 REM Corresponding lines from the shell script are printed before the matching batch file commands
 


### PR DESCRIPTION
## This PR…

- reverts the deletion of this line in #42 and raises max. memory to 3GB
- in context to https://help.openstreetmap.org/questions/21642/osmosis-outofmemory-java-heap-space
- closes #156

## How to test

1. see #156 

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
