### PR TITLE
[BUGFIX] Include wahoomc.init module in published PyPI version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-packages = wahoomc
+packages = wahoomc, wahoomc.init
 python_requires = >=3.7
 install_requires =
     requests==2.28.*


### PR DESCRIPTION
## This PR…

- includes the directory `wahoomc/init` to the published package in PyPI

## Considerations and implementations
The whole .init cli input was not working because the directory `wahoomc/init` is not included.
Without that, this is the output of version `3.0.0`

```
(gdal-user) <username>@<computer> % python -m wahoomc.init    
/Users/bkreusc/opt/anaconda3/envs/gdal-user/bin/python: No module named wahoomc.init
```

## How to test

see above

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
