### PR TITLE
[FEAT] install: Check installed version against latest published version on PyPI

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -4,12 +4,15 @@ tests for setup functions
 import unittest
 import platform
 import os
+import pkg_resources
 
 # import custom python packages
-from wahoomc.setup_functions import is_program_installed, is_map_writer_plugin_installed, read_version_last_run
+from wahoomc.setup_functions import is_program_installed, is_map_writer_plugin_installed, \
+    read_version_last_run
 from wahoomc.constants_functions import get_tooling_win_path
-from wahoomc.constants import USER_WAHOO_MC
+from wahoomc.constants import USER_WAHOO_MC, VERSION
 from wahoomc.file_directory_functions import write_json_file_generic
+from wahoomc.downloader import get_latest_pypi_version
 
 
 class TestSetup(unittest.TestCase):
@@ -89,6 +92,16 @@ class TestConfigFile(unittest.TestCase):
                                 "version_last_run": '2.0.3'})
 
         self.assertNotEqual('2.0.2', read_version_last_run())
+
+    def test_version_constants_against_pypi(self):
+        """
+        tests, if the version of constants.py is equal to the latest available version on PyPI
+        """
+        latest_version = pkg_resources.parse_version(
+            get_latest_pypi_version()).public
+
+        self.assertEqual(
+            VERSION, latest_version)
 
 
 if __name__ == '__main__':

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -11,6 +11,7 @@ import sys
 import time
 import logging
 import platform
+import requests
 
 # import custom python packages
 from wahoomc.file_directory_functions import download_url_to_file, unzip
@@ -116,6 +117,18 @@ def download_tooling_win():
 
             download_file(get_tooling_win_path('osmfilter.exe', in_user_dir=True),
                           'http://m.m.i24.cc/osmfilter.exe')
+
+
+def get_latest_pypi_version():
+    """
+    get latest wahoomc version available on PyPI
+    """
+    try:
+        response = requests.get(
+            'https://pypi.org/pypi/wahoomc/json', timeout=1)
+        return response.json()['info']['version']
+    except (requests.ConnectionError, requests.Timeout):
+        return None
 
 
 class Downloader:

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -10,7 +10,8 @@ import logging
 from wahoomc.input import process_call_of_the_tool, cli_init
 from wahoomc.setup_functions import initialize_work_directories, \
     check_installation_of_required_programs, write_config_file, \
-    adjustments_due_to_breaking_changes, copy_jsons_from_repo_to_user
+    adjustments_due_to_breaking_changes, copy_jsons_from_repo_to_user, \
+    check_installed_version_against_latest_pypi
 from wahoomc.downloader import download_tooling_win
 
 from wahoomc.osm_maps_functions import OsmMaps
@@ -36,6 +37,7 @@ def run(run_level):
     adjustments_due_to_breaking_changes()
     download_tooling_win()
     check_installation_of_required_programs()
+    check_installed_version_against_latest_pypi()
 
     if run_level == 'init':
         o_input_data = cli_init()

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -33,11 +33,11 @@ def run(run_level):
 
     # initializing work directories needs to be the first call,
     # because other setup stuff relies on that (breaking changes)
+    check_installed_version_against_latest_pypi()
     initialize_work_directories()
     adjustments_due_to_breaking_changes()
     download_tooling_win()
     check_installation_of_required_programs()
-    check_installed_version_against_latest_pypi()
 
     if run_level == 'init':
         o_input_data = cli_init()

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -11,6 +11,7 @@ import shutil
 from pathlib import Path
 import sys
 import pkg_resources
+import requests
 
 # import custom python packages
 from wahoomc.file_directory_functions import move_content, write_json_file_generic, \
@@ -191,9 +192,26 @@ def copy_jsons_from_repo_to_user(folder, file=''):
     log.debug('# Copy "%s" files from repo to directory if not existing: %s',
               folder, absolute_paths[0])
 
-    # copy files of gitcommon package directory to user directory
+    # copy files of wahoomc package directory to user directory
     copy_or_move_files_and_folder(
         absolute_paths[1], absolute_paths[0], delete_from_dir=False)
 
-    log.info('# Copy "%s" files from repo or gitcommon to directory if not existing: %s : OK',
+    log.info('# Copy "%s" files from wahoomc installation to directory if not existing: %s : OK',
              folder, absolute_paths[0])
+
+
+def check_installed_version_against_latest_pypi():
+    """
+    get latest wahoomc version available on PyPI and compare with locally installed version
+    """
+    # get latest wahoomc version available on PyPI
+    response = requests.get('https://pypi.org/pypi/wahoomc/json', timeout=15)
+    latest_version = response.json()['info']['version']
+
+    # compare installed version against latest and issue a info if a new version is available
+    if pkg_resources.parse_version(VERSION) < pkg_resources.parse_version(latest_version):
+        log.info('# A new version of wahoomc is available: "%s". You have installed version "%s". \
+                \nYou can upgrade wahoomc with "pip install wahoomc --upgrade" \
+                \nRelease notes are here: https://github.com/treee111/wahooMapsCreator/releases/latest \
+                \n',
+                 latest_version, VERSION)

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -205,8 +205,12 @@ def check_installed_version_against_latest_pypi():
     get latest wahoomc version available on PyPI and compare with locally installed version
     """
     # get latest wahoomc version available on PyPI
-    response = requests.get('https://pypi.org/pypi/wahoomc/json', timeout=15)
-    latest_version = response.json()['info']['version']
+    try:
+        response = requests.get(
+            'https://pypi.org/pypi/wahoomc/json', timeout=3)
+        latest_version = response.json()['info']['version']
+    except requests.exceptions.ConnectTimeout:
+        return
 
     # compare installed version against latest and issue a info if a new version is available
     if pkg_resources.parse_version(VERSION) < pkg_resources.parse_version(latest_version):

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -212,7 +212,7 @@ def check_installed_version_against_latest_pypi():
             and pkg_resources.parse_version(VERSION) < pkg_resources.parse_version(latest_version):
         log.info('\n\nUpdate available! \
                 \nA new version of wahoomc is available: "%s". You have installed version "%s". \
-                \nYou can upgrade wahoomc with "pip install wahoomc --upgrade" \
-                \nRelease notes are here: https://github.com/treee111/wahooMapsCreator/releases/latest \
+                \nUpgrade wahoomc with "pip install wahoomc --upgrade". \
+                \nRelease notes are here: https://github.com/treee111/wahooMapsCreator/releases/latest. \
                 \n',
                  latest_version, VERSION)

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -210,7 +210,8 @@ def check_installed_version_against_latest_pypi():
     # compare installed version against latest and issue a info if a new version is available
     if latest_version \
             and pkg_resources.parse_version(VERSION) < pkg_resources.parse_version(latest_version):
-        log.info('# A new version of wahoomc is available: "%s". You have installed version "%s". \
+        log.info('\n\nUpdate available! \
+                \nA new version of wahoomc is available: "%s". You have installed version "%s". \
                 \nYou can upgrade wahoomc with "pip install wahoomc --upgrade" \
                 \nRelease notes are here: https://github.com/treee111/wahooMapsCreator/releases/latest \
                 \n',

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -11,12 +11,12 @@ import shutil
 from pathlib import Path
 import sys
 import pkg_resources
-import requests
 
 # import custom python packages
 from wahoomc.file_directory_functions import move_content, write_json_file_generic, \
     read_json_file_generic, delete_o5m_pbf_files_in_folder, copy_or_move_files_and_folder
 from wahoomc.constants_functions import get_tooling_win_path, get_absolute_dir_user_or_repo
+from wahoomc.downloader import get_latest_pypi_version
 
 from wahoomc.constants import USER_WAHOO_MC
 from wahoomc.constants import USER_DL_DIR
@@ -205,15 +205,11 @@ def check_installed_version_against_latest_pypi():
     get latest wahoomc version available on PyPI and compare with locally installed version
     """
     # get latest wahoomc version available on PyPI
-    try:
-        response = requests.get(
-            'https://pypi.org/pypi/wahoomc/json', timeout=3)
-        latest_version = response.json()['info']['version']
-    except requests.exceptions.ConnectTimeout:
-        return
+    latest_version = get_latest_pypi_version()
 
     # compare installed version against latest and issue a info if a new version is available
-    if pkg_resources.parse_version(VERSION) < pkg_resources.parse_version(latest_version):
+    if latest_version \
+            and pkg_resources.parse_version(VERSION) < pkg_resources.parse_version(latest_version):
         log.info('# A new version of wahoomc is available: "%s". You have installed version "%s". \
                 \nYou can upgrade wahoomc with "pip install wahoomc --upgrade" \
                 \nRelease notes are here: https://github.com/treee111/wahooMapsCreator/releases/latest \


### PR DESCRIPTION
## This PR…

- grabs the latest public version of `wahomc` published to PyPI and compares the version against the locally installed one
- if there is a newer version available, this will be displayed and also how to upgrade

## Screenshot

<img width="617" alt="grafik" src="https://user-images.githubusercontent.com/53038537/204374704-e0539f02-0965-45ef-82c6-fdbb9cc7e607.png">

## How to test

1. have a older version installed or simulated via `wahoomc/constants.py`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/.github/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
