### PR TITLE
[DEV] macOS: Check .osm.pbf files in unittests with `osmium diff` (due to osmium-tool upgrade)

### DIFF
--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -169,14 +169,19 @@ class TestGeneratedFiles(unittest.TestCase):
     def compare_two_map_files(self, given_file, calculated_file):
         """
         compare two given (map) files for equalness.
-        classic map files are compared using CLI command "osmium diff",
-        the others are compared using "filecmp.cmp"
+        macOS / Linux:
+        - classic map files are compared using CLI command "osmium diff",
+        - the others are compared using "filecmp.cmp"
+        Windows:
+        - compare all files using "filecmp.cmp".
+          osmosis and osmconvert do not offer a possibility to compare with returning a errorcode
         """
 
         no_osmosis_file_extensions = ['shx', 'shp', 'prj']
 
         # some file extensions can not be comapared using osmium
-        if given_file.split('.')[-1] in no_osmosis_file_extensions:
+        if given_file.split('.')[-1] in no_osmosis_file_extensions or \
+                platform.system() == "Windows":
             self.assertTrue(filecmp.cmp(given_file, calculated_file,
                                         shallow=False), f'not equal: {calculated_file}. Using filecmp.cmp.')
         # compare map files using osmium

--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -188,7 +188,7 @@ class TestGeneratedFiles(unittest.TestCase):
         else:
             cmd = ['osmium', 'diff', '-q',
                    given_file, calculated_file]
-            result = subprocess.run(cmd)
+            result = subprocess.run(cmd, check=False)
 
             self.assertEqual(
                 0, result.returncode, f'not equal: {calculated_file}. Using osmium diff.')


### PR DESCRIPTION
## This PR…

- by unittests generated files will be compared with the files in the repo in two ways for macOS:
  - `osmium diff` for osm files
  - `filecmp.cmp` for other used files

## Considerations and implementations

This change is needed due to the new osmium-tool version [v1.15.0](https://github.com/osmcode/osmium-tool/releases/tag/v1.15.0).

The "generator" content is different. See the files in the repository on the left and the newly generated on the right:
<img width="1147" alt="Ohne Titel" src="https://user-images.githubusercontent.com/53038537/216373177-7c9bea75-236d-4fe9-b3b7-071ca4df74fa.png">

The chagne is due to osmium-tool v1.15.0. Most probably it is just this change in the .osm.pbf files: "generator=osmium/1.15.0". That would mean this difference would happen with any new version of osmium-tool other than the current 1.14.0.

additional links:
https://wiki.openstreetmap.org/wiki/PBF_Format#Encoding_OSM_entities_into_fileblocks
https://osmcode.org/file-formats-manual/

## How to test

1. run unittests on branch develop with osmium-tool v1.14.0 and v1.15.0
2. run unitttests on branch fix-unittests

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
