### PR TITLE
[FEAT] macOS: Download mapwriter plugin during usage instead of manually copying during setup

### DIFF
--- a/docs/QUICKSTART_ANACONDA.md
+++ b/docs/QUICKSTART_ANACONDA.md
@@ -71,16 +71,6 @@ brew install osmium-tool
 brew install osmosis
 ```
 
-3. Install mapsforge-map-writer plugin (Osmosis Plugin)
-* Download the [mapsforge-map-writer](https://search.maven.org/search?q=a:mapsforge-map-writer) plugin, click on "file_download" and select "jar-with-dependecies.jar".
-* Create this directory when it doesn't exist: `~/.openstreetmap/osmosis/plugins`. For example via terminal:
-```
-cd ~
-mkdir -p .openstreetmap/osmosis/plugins
-```
-* Put the .jar into the `plugins` directory. You may have to enable showing hidden folders in finder via `Command + Shift + . (period)`
-* more information: https://github.com/mapsforge/mapsforge/blob/master/docs/Getting-Started-Map-Writer.md#plugin-installation
-
 # wahooMapsCreator
 ## Create Anaconda Environment
 1. Open terminal (macOS/Linux) or **Anaconda Prompt** (Windows, via Startmenu)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -163,7 +163,6 @@ class TestDownloader(unittest.TestCase):
             if os.path.exists(path):
                 shutil.rmtree(path)
 
-            os.makedirs(constants.USER_TOOLING_WIN_DIR, exist_ok=True)
             download_tooling()
 
             self.assertTrue(

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -14,7 +14,7 @@ import platform
 from wahoomc.downloader import older_than_x_days
 from wahoomc.downloader import download_file
 from wahoomc.downloader import get_osm_pbf_filepath_url
-from wahoomc.downloader import download_tooling_win
+from wahoomc.downloader import download_tooling
 from wahoomc.downloader import Downloader
 from wahoomc import constants
 from wahoomc.constants_functions import get_tooling_win_path
@@ -158,16 +158,36 @@ class TestDownloader(unittest.TestCase):
         Test if Windows tooling files download is successful
         """
         if platform.system() == "Windows":
-            path = os.path.join(constants.USER_TOOLING_WIN_DIR)
+            path = constants.USER_TOOLING_WIN_DIR
 
             if os.path.exists(path):
                 shutil.rmtree(path)
 
             os.makedirs(constants.USER_TOOLING_WIN_DIR, exist_ok=True)
-            download_tooling_win()
+            download_tooling()
 
             self.assertTrue(
                 os.path.exists(get_tooling_win_path('osmfilter.exe', in_user_dir=True)))
+
+    def test_download_macos_files(self):
+        """
+        Test if macOS tooling files download is successful
+        """
+        if platform.system() != "Windows":
+            path = os.path.join(str(constants.USER_DIR), '.openstreetmap', 'osmosis',
+                                'plugins', 'mapsforge-map-writer-0.18.0-jar-with-dependencies.jar')
+
+            if os.path.exists(path):
+                os.remove(path)
+
+            self.assertFalse(
+                os.path.exists(path))
+
+            # os.makedirs(constants.USER_TOOLING_WIN_DIR, exist_ok=True)
+            download_tooling()
+
+            self.assertTrue(
+                os.path.exists(path))
 
 
 if __name__ == '__main__':

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -163,7 +163,11 @@ class TestDownloader(unittest.TestCase):
             if os.path.exists(path):
                 shutil.rmtree(path)
 
+            self.assertFalse(os.path.exists(path))
+
             download_tooling()
+
+            self.assertTrue(os.path.exists(path))
 
             self.assertTrue(
                 os.path.exists(get_tooling_win_path('osmfilter.exe', in_user_dir=True)))
@@ -179,14 +183,11 @@ class TestDownloader(unittest.TestCase):
             if os.path.exists(path):
                 os.remove(path)
 
-            self.assertFalse(
-                os.path.exists(path))
+            self.assertFalse(os.path.exists(path))
 
-            # os.makedirs(constants.USER_TOOLING_WIN_DIR, exist_ok=True)
             download_tooling()
 
-            self.assertTrue(
-                os.path.exists(path))
+            self.assertTrue(os.path.exists(path))
 
 
 if __name__ == '__main__':

--- a/wahoomc/constants.py
+++ b/wahoomc/constants.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 
 # User
+USER_DIR = str(Path.home())
 USER_WAHOO_MC = os.path.join(str(Path.home()), 'wahooMapsCreatorData')
 USER_DL_DIR = os.path.join(USER_WAHOO_MC, '_download')
 USER_MAPS_DIR = os.path.join(USER_DL_DIR, 'maps')

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -108,6 +108,8 @@ def download_tooling():
 
     # Windows
     if platform.system() == "Windows":
+        os.makedirs(USER_TOOLING_WIN_DIR, exist_ok=True)
+
         if not os.path.isfile(OSMOSIS_WIN_FILE_PATH):
             log.info('# Need to download Osmosis application for Windows')
             download_file(OSMOSIS_WIN_FILE_PATH,

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -24,6 +24,7 @@ from wahoomc.constants import LAND_POLYGONS_PATH
 from wahoomc.constants import GEOFABRIK_PATH
 from wahoomc.constants import OSMOSIS_WIN_FILE_PATH
 from wahoomc.constants import USER_TOOLING_WIN_DIR
+from wahoomc.constants import USER_DIR
 
 log = logging.getLogger('main-logger')
 
@@ -92,11 +93,19 @@ def get_osm_pbf_filepath_url(country):
     return map_file_path, url
 
 
-def download_tooling_win():
+def download_tooling():
     """
-    check for Windows tooling and download if not here already
-    this is done to bring down the filesize of the python module
+    Windows
+    - check for Windows tooling
+    - download if Windows tooling is not available
+    --> this is done to bring down the filesize of the python module
+
+    macOS
+    - check for mapwriter plugin and download if not existing
     """
+
+    mapwriter_plugin_url = 'https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.18.0/mapsforge-map-writer-0.18.0-jar-with-dependencies.jar'
+
     # Windows
     if platform.system() == "Windows":
         if not os.path.isfile(OSMOSIS_WIN_FILE_PATH):
@@ -105,18 +114,25 @@ def download_tooling_win():
                           'https://github.com/openstreetmap/osmosis/releases/download/0.48.3/osmosis-0.48.3.zip',
                           get_tooling_win_path('Osmosis', in_user_dir=True))
 
-        mapwriter_plugin_path = os.path.join(USER_TOOLING_WIN_DIR,
-                                             'Osmosis', 'lib', 'default', 'mapsforge-map-writer-0.18.0-jar-with-dependencies.jar')
-        if not os.path.isfile(mapwriter_plugin_path):
-            log.info('# Need to download Osmosis mapwriter plugin for Windows')
-            download_file(mapwriter_plugin_path,
-                          'https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.18.0/mapsforge-map-writer-0.18.0-jar-with-dependencies.jar')
-
         if not os.path.isfile(get_tooling_win_path('osmfilter.exe', in_user_dir=True)):
             log.info('# Need to download osmfilter application for Windows')
 
             download_file(get_tooling_win_path('osmfilter.exe', in_user_dir=True),
                           'http://m.m.i24.cc/osmfilter.exe')
+
+        mapwriter_plugin_path = os.path.join(USER_TOOLING_WIN_DIR,
+                                             'Osmosis', 'lib', 'default', 'mapsforge-map-writer-0.18.0-jar-with-dependencies.jar')
+
+    # Non-Windows
+    else:
+        mapwriter_plugin_path = os.path.join(
+            str(USER_DIR), '.openstreetmap', 'osmosis', 'plugins', 'mapsforge-map-writer-0.18.0-jar-with-dependencies.jar')
+
+    if not os.path.isfile(mapwriter_plugin_path):
+        log.info('# Need to download Osmosis mapwriter plugin')
+        # create plugins directory
+        os.makedirs(os.path.dirname(mapwriter_plugin_path), exist_ok=True)
+        download_file(mapwriter_plugin_path, mapwriter_plugin_url)
 
 
 def get_latest_pypi_version():

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -12,7 +12,7 @@ from wahoomc.setup_functions import initialize_work_directories, \
     check_installation_of_required_programs, write_config_file, \
     adjustments_due_to_breaking_changes, copy_jsons_from_repo_to_user, \
     check_installed_version_against_latest_pypi
-from wahoomc.downloader import download_tooling_win
+from wahoomc.downloader import download_tooling
 
 from wahoomc.osm_maps_functions import OsmMaps
 from wahoomc.osm_maps_functions import OsmData
@@ -36,7 +36,7 @@ def run(run_level):
     check_installed_version_against_latest_pypi()
     initialize_work_directories()
     adjustments_due_to_breaking_changes()
-    download_tooling_win()
+    download_tooling()
     check_installation_of_required_programs()
 
     if run_level == 'init':

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -24,7 +24,6 @@ from wahoomc.constants import USER_MAPS_DIR
 from wahoomc.constants import USER_OUTPUT_DIR
 from wahoomc.constants import USER_CONFIG_DIR
 from wahoomc.constants import VERSION
-from wahoomc.constants import USER_TOOLING_WIN_DIR
 
 log = logging.getLogger('main-logger')
 
@@ -40,9 +39,6 @@ def initialize_work_directories():
     os.makedirs(USER_MAPS_DIR, exist_ok=True)
     os.makedirs(USER_OUTPUT_DIR, exist_ok=True)
     os.makedirs(USER_CONFIG_DIR, exist_ok=True)
-
-    if platform.system() == "Windows":
-        os.makedirs(USER_TOOLING_WIN_DIR, exist_ok=True)
 
 
 def move_old_content_into_new_dirs():


### PR DESCRIPTION
## This PR…

- downloads and moves the mapwriter plugin to the correct location for macOS and Linux in the same way it was already implemented for Windows
- closes #89

## Considerations and implementations

Doing stuff in the same way as already in Windows is a good idea.
With this PR, some refactorings are also included which were found during coding.

## How to test

1. delete mapwriter plugin / whole `~/.openstreetmap` directory
2. run wahooMapsCreator and process a small country
3. check output of processing and if the mapwriter plugin was downloaded

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
