### PR TITLE
[DEV] enable Github action to update `latest` release

### DIFF
--- a/.github/workflows/git-release-pre.yml
+++ b/.github/workflows/git-release-pre.yml
@@ -26,7 +26,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UNRELEASED: "update"
           ALLOW_EMPTY_CHANGELOG: true
-          DRAFT_RELEASE: true
         with:
           args: |
             dist/*.zip

--- a/.github/workflows/git-release-test.yml
+++ b/.github/workflows/git-release-test.yml
@@ -32,7 +32,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UNRELEASED: "update"
           ALLOW_EMPTY_CHANGELOG: true
-          DRAFT_RELEASE: true
         with:
           args: |
             dist/*.zip


### PR DESCRIPTION
## This PR…

- because of `DRAFT_RELEASE: true`, updating the latest release and tag did not work. Now it works again ;-)

## How to test

1. create branch `git-release` and push change
2. Check `latest` tag and release 

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
