### PR TITLE
[BREAKING] Downgrade required Python version to 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/conda_env/gdal-dev.yml
+++ b/conda_env/gdal-dev.yml
@@ -2,8 +2,8 @@ name: gdal-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
-  - gdal=3.6.*
+  - python=3.10
+  - gdal=3.4.*
   - requests=2.28.*
   - pylint=2.15.*
   - geojson=2.5.*

--- a/conda_env/gdal-user.yml
+++ b/conda_env/gdal-user.yml
@@ -2,9 +2,9 @@ name: gdal-user
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.10
   - geojson=2.5.*
-  - gdal=3.6.*
+  - gdal=3.4.*
   - pip
   - pip:
       - wahoomc==3.2.0

--- a/docs/QUICKSTART_ANACONDA.md
+++ b/docs/QUICKSTART_ANACONDA.md
@@ -76,7 +76,7 @@ brew install osmosis
 1. Open terminal (macOS/Linux) or **Anaconda Prompt** (Windows, via Startmenu)
 2. Create a new Anaconda environment with needed packages
 ```
-conda create -n gdal-user python=3.11 geojson=2.5 gdal=3.6 pip --channel conda-forge --override-channels
+conda create -n gdal-user python=3.10 geojson=2.5 gdal=3.4 pip --channel conda-forge --override-channels
 ```
 3. activate Anaconda environment with the command printed out (this needs to be done each time you want to use wahooMapsCreator maps)
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 
 [options]
 packages = wahoomc, wahoomc.init
-python_requires = >=3.11
+python_requires = >=3.10
 install_requires =
     requests==2.28.*
     shapely==1.8.*


### PR DESCRIPTION
## This PR…

- makes changes in all relevant files to require Python version 3.10
- goes one python version back from #166
- enables #188 to be implemented

## Considerations and implementations

For implementing #188, matplotlib v3.4.3 is needed and can not be installed in Python 3.11.

## How to test

1. ...
2. ...

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
