### PR TITLE
[FEAT] Allow processing of multiple countries via CLI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -237,6 +237,36 @@
                 "-md",
                 "100"
             ]
+        },
+        {
+            "name": "country: liechtenstein & suisse",
+            "type": "python",
+            "request": "launch",
+            "module": "wahoomc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-co",
+                "liechtenstein,switzerland",
+                "-c",
+                "-md",
+                "100"
+            ]
+        },
+        {
+            "name": "country: malta & liechtenstein",
+            "type": "python",
+            "request": "launch",
+            "module": "wahoomc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-co",
+                "malta,liechtenstein",
+                "-c",
+                "-md",
+                "100"
+            ]
         }
     ]
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 4.0.0a4
+version = 4.0.0a6
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 4.0.0a2
+version = 4.0.0a4
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 4.0.0a1
+version = 4.0.0a2
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 4.0.0a6
+version = 4.0.0a9
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 4.0.0a0
+version = 4.0.0a1
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -8,7 +8,6 @@ import unittest
 # import custom python packages
 from wahoomc.osm_maps_functions import OsmData
 from wahoomc.osm_maps_functions import OsmMaps
-from wahoomc.osm_maps_functions import get_xy_coordinates_from_input
 # from wahoomc.osm_maps_functions import TileNotFoundError
 from wahoomc.input import InputData
 from wahoomc import file_directory_functions as fd_fct
@@ -143,45 +142,6 @@ class TestOSMMapsInput(unittest.TestCase):
 
         result = o_osm_data.country_name
         self.assertEqual(result, 'malta')
-
-    def test_splitting_of_single_xy_coordinate(self):
-        """
-        use static json files in the repo to calculate relevant tiles
-        """
-
-        xy_tuple = get_xy_coordinates_from_input("133/88")
-        self.assertEqual(xy_tuple, [{"x": 133, "y": 88}])
-
-        xy_tuple = get_xy_coordinates_from_input("11/92")
-        self.assertEqual(xy_tuple, [{"x": 11, "y": 92}])
-
-        xy_tuple = get_xy_coordinates_from_input("138/100")
-        self.assertEqual(xy_tuple, [{"x": 138, "y": 100}])
-
-    def test_splitting_of_multiple_xy_coordinate(self):
-        """
-        use static json files in the repo to calculate relevant tiles
-        """
-
-        xy_tuple = get_xy_coordinates_from_input("133/88,138/100")
-        expected_result = [{"x": 133, "y": 88}, {"x": 138, "y": 100}]
-
-        self.assertEqual(xy_tuple, expected_result)
-
-    # def test_get_tile_via_xy_coordinate_error(self):
-    #     """
-    #     use static json files in the repo to calculate a not-existing tile.
-
-    #     does not error out due to new Geofabrik Json processing. Nevertheless, the tile is not existing
-    #     only +/- 180 -/+90: https://epsg.io/4326
-    #     """
-
-    #     o_geofabrik = XYGeofabrik([{"x": 200, "y": 1}])
-
-    #     # tiles =
-
-    #     with self.assertRaises(TileNotFoundError):
-    #         o_geofabrik.get_tiles_of_wanted_map()
 
     def test_encoding_open_sea_osm(self):
         """

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -39,6 +39,13 @@ class TestOsmMapsCalculation(unittest.TestCase):
         self.process_and_check_border_countries(
             'germany', True, expected_result, 'country')
 
+        # germany,malta
+        expected_result = {'czech-republic': {}, 'germany': {}, 'austria': {}, 'liechtenstein': {},
+                           'switzerland': {}, 'italy': {}, 'netherlands': {}, 'belgium': {},
+                           'luxembourg': {}, 'france': {}, 'poland': {}, 'denmark': {}, 'sweden': {}, 'malta': {}}
+        self.process_and_check_border_countries(
+            'germany,malta', True, expected_result, 'country')
+
     def test_calc_border_countries_input_xy_coordinates_1tile(self):
         """
         Test initialized border countries
@@ -77,7 +84,15 @@ class TestOsmMapsCalculation(unittest.TestCase):
         self.process_and_check_border_countries(
             'china', False, {'china': {}}, 'country')
 
-    def test_calc_without_border_countries__xy_coordinates_1tile(self):
+        # malta,liechtenstein
+        self.process_and_check_border_countries(
+            'malta,liechtenstein', False, {'malta': {}, 'liechtenstein': {}}, 'country')
+
+        # malta,tunisia
+        self.process_and_check_border_countries(
+            'malta,tunisia', False, {'malta': {}, 'tunisia': {}}, 'country')
+
+    def test_calc_without_border_countries_xy_coordinates_1tile(self):
         """
         Test initialized countries without border countries
         - of one tile
@@ -88,7 +103,7 @@ class TestOsmMapsCalculation(unittest.TestCase):
         self.process_and_check_border_countries(
             "133/88", False, expected_result, 'xy_coordinate')
 
-    def test_calc_without_border_countries__xy_coordinates_2tiles(self):
+    def test_calc_without_border_countries_xy_coordinates_2tiles(self):
         """
         Test initialized countries without border countries
         - of two tiles

--- a/wahoomc/geofabrik.py
+++ b/wahoomc/geofabrik.py
@@ -8,11 +8,9 @@ functions and object for managing OSM maps
 import sys
 import math
 import logging
-import geojson
 from shapely.geometry import Polygon, shape
 
 # import custom python packages
-from wahoomc.constants import GEOFABRIK_PATH
 from wahoomc.constants import special_regions, block_download
 from wahoomc.geofabrik_json import GeofabrikJson
 
@@ -20,6 +18,7 @@ log = logging.getLogger('main-logger')
 
 
 class InformalGeofabrikInterface:
+    """Informal class for Geofabrik processing"""
     wanted_maps = []
     tiles = []
     border_countries = {}
@@ -48,7 +47,7 @@ class InformalGeofabrikInterface:
         """find needed countries for requested country or X/Y combination"""
         pass
 
-    def compose_bouding_box(self, input) -> dict:
+    def compose_bouding_box(self, bounds) -> dict:
         """calculate bounding box based on geometry or X/Y combination"""
         pass
 
@@ -56,7 +55,7 @@ class InformalGeofabrikInterface:
 class CountryGeofabrik(InformalGeofabrikInterface):
     """Geofabrik processing for countries"""
 
-    def __init__(self, input):
+    def __init__(self, input_countries):
         """
         :param input: string with countries: 'malta' or 'malta, switzerland'
         :returns: object for country geofabrik processing
@@ -64,9 +63,9 @@ class CountryGeofabrik(InformalGeofabrikInterface):
         self.wanted_maps = []
 
         # input parameters
-        countries = get_countries_from_input(input)
+        input_countries = get_countries_from_input(input_countries)
 
-        for country in countries:
+        for country in input_countries:
             self.wanted_maps.append(self.o_geofabrik_json.translate_id_no_to_geofabrik(
                 country))
 
@@ -255,7 +254,7 @@ class CountryGeofabrik(InformalGeofabrikInterface):
 class XYGeofabrik(InformalGeofabrikInterface):
     """Geofabrik processing for X/Y coordinates"""
 
-    def __init__(self, input):
+    def __init__(self, input_xy_coordinates):
         """
         :param input: string with xy-coordinates: 133/88 or 133/88,134/88
         :returns: object for xy geofabrik processing
@@ -263,7 +262,7 @@ class XYGeofabrik(InformalGeofabrikInterface):
         # input parameters
 
         # use Geofabrik-URL to get the relevant tiles
-        self.wanted_maps = get_xy_coordinates_from_input(input)
+        self.wanted_maps = get_xy_coordinates_from_input(input_xy_coordinates)
 
     def get_tiles_of_wanted_map_single(self, wanted_map):
         """Overrides InformalGeofabrikInterface.get_tiles_of_wanted_map_single()"""
@@ -361,8 +360,8 @@ class XYGeofabrik(InformalGeofabrikInterface):
     def compose_shape(self, bbox_tiles):
         coords = [(bbox_tiles[0]["tile_top"], bbox_tiles[0]["tile_left"]), (bbox_tiles[0]["tile_top"], bbox_tiles[0]["tile_right"]),
                   (bbox_tiles[0]["tile_bottom"], bbox_tiles[0]["tile_right"]), (bbox_tiles[0]["tile_bottom"], bbox_tiles[0]["tile_left"])]
-        p = Polygon(coords)
-        wanted_region = shape(p)
+        coords_polygon = Polygon(coords)
+        wanted_region = shape(coords_polygon)
         return wanted_region
 
 

--- a/wahoomc/geofabrik.py
+++ b/wahoomc/geofabrik.py
@@ -31,9 +31,15 @@ class InformalGeofabrikInterface:
         """Get the relevant tiles for ONE wanted country or X/Y coordinate"""
         pass
 
-    def get_tiles_of_wanted_map(self) -> str:
-        """Get the relevant tiles for the countries or X/Y coordinates"""
-        pass
+    def get_tiles_of_wanted_map(self):
+        """Overrides InformalGeofabrikInterface.get_tiles_of_wanted_map()"""
+
+        tiles_of_input = []
+
+        for country in self.wanted_maps:
+            tiles_of_input.extend(self.get_tiles_of_wanted_map_single(country))
+
+        return tiles_of_input
 
     def find_needed_countries(self, bbox_tiles, wanted_map, wanted_region_polygon) -> dict:
         """find needed countries for requested country or X/Y combination"""
@@ -56,16 +62,6 @@ class CountryGeofabrik(InformalGeofabrikInterface):
         for country in countries:
             self.wanted_maps.append(self.o_geofabrik_json.translate_id_no_to_geofabrik(
                 country))
-
-    def get_tiles_of_wanted_map(self):
-        """Overrides InformalGeofabrikInterface.get_tiles_of_wanted_map()"""
-
-        tiles_of_input = []
-
-        for country in self.wanted_maps:
-            tiles_of_input.extend(self.get_tiles_of_wanted_map_single(country))
-
-        return tiles_of_input
 
     def get_tiles_of_wanted_map_single(self, wanted_map):
         """Overrides InformalGeofabrikInterface.get_tiles_of_wanted_map_single()"""

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -38,7 +38,7 @@ def process_call_of_the_tool():
 
     # create the parser for the "cli" command
     parser_cli = subparsers.add_parser(
-        'cli', help='Run the tool via command line interface')
+        'cli', help='Run the tool via command line interface', formatter_class=argparse.RawTextHelpFormatter)
 
     # group: primary input parameters to create map for. One needs to be given
     primary_args = parser_cli.add_argument_group(
@@ -47,10 +47,10 @@ def process_call_of_the_tool():
         required=True)
     # country to create maps for
     primary_args_excl.add_argument(
-        "-co", "--country", help="country to generate maps for")
+        "-co", "--country", help="country to generate maps for.\nExample: -co malta, multiple countries separated by comma: -co malta,italy")
     # X/Y coordinates to create maps for
     primary_args_excl.add_argument(
-        "-xy", "--xy_coordinates", help="x/y coordinates to generate maps for. Example: 133/88")
+        "-xy", "--xy_coordinates", help="x/y coordinates to generate maps for.\nExample: -xy 133/88, multiple xy coordinates separated by comma: -xy 133/88,134/89")
 
     # group: options for map generation
     options_args = parser_cli.add_argument_group(

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -15,6 +15,7 @@ from tkinter import ttk
 # import custom python packages
 from wahoomc.geofabrik_json import GeofabrikJson
 from wahoomc.geofabrik_json import CountyIsNoGeofabrikCountry
+from wahoomc.geofabrik import get_countries_from_input
 
 o_geofabrik_json = GeofabrikJson()
 
@@ -205,14 +206,18 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
             sys.exit(
                 "Country and X/Y coordinates are given. Only one of both is allowed!")
         elif self.country:
-            try:
-                self.country = o_geofabrik_json.translate_id_no_to_geofabrik(
-                    self.country)
-                return True
-            except CountyIsNoGeofabrikCountry:
-                sys.exit(
-                    f"Entered country '{self.country}' is not a geofabrik country. Please check this URL for possible countries \
-                        https://download.geofabrik.de/index.html!")
+            # countries =
+            for country in get_countries_from_input(self.country):
+                try:
+                    country = o_geofabrik_json.translate_id_no_to_geofabrik(
+                        country)
+                except CountyIsNoGeofabrikCountry:
+                    sys.exit(
+                        f"Entered country '{country}' is not a geofabrik country. Please check this URL for possible countries \
+                            https://download.geofabrik.de/index.html!")
+
+            # if we made it until here, sys.exit() was not called and therefore all countries OK ;-)
+            return True
         else:
             return True
 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -36,26 +36,6 @@ class TileNotFoundError(Exception):
     """Raised when no tile is found for x/y combination"""
 
 
-def get_xy_coordinates_from_input(input_xy_coordinates):
-    """
-    extract/split x/y combinations by given X/Y coordinates.
-    input should be "188/88" or for multiple values "188/88,100/10,109/99".
-    returns a list of x/y combinations as integers
-    """
-
-    xy_combinations = []
-
-    # split by "," first for multiple x/y combinations, then by "/" for x and y value
-    for xy_coordinate in input_xy_coordinates.split(","):
-        splitted = xy_coordinate.split("/")
-
-        if len(splitted) == 2:
-            xy_combinations.append(
-                {"x": int(splitted[0]), "y": int(splitted[1])})
-
-    return xy_combinations
-
-
 def run_subprocess_and_log_output(cmd, error_message, cwd=""):
     """
     run given cmd-subprocess and issue error message if wished
@@ -185,11 +165,7 @@ class OsmData():  # pylint: disable=too-few-public-methods
         log.info(
             '# Input X/Y coordinates: %s.', o_input_data.xy_coordinates)
 
-        # use Geofabrik-URL to get the relevant tiles
-        xy_coordinates = get_xy_coordinates_from_input(
-            o_input_data.xy_coordinates)
-
-        o_geofabrik = XYGeofabrik(xy_coordinates)
+        o_geofabrik = XYGeofabrik(o_input_data.xy_coordinates)
         # find the tiles for  x/y combinations in the geofabrik json files
         self.tiles = o_geofabrik.get_tiles_of_wanted_map()
 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -221,7 +221,11 @@ class CountryOsmData(InformalOsmDataInterface):
         country name is the country
         >1 countries are separated by underscore
         """
-        self.country_name = self.input_country
+        for country in self.o_geofabrik.wanted_maps:
+            if not self.country_name:
+                self.country_name = country
+            else:
+                self.country_name = f'{self.country_name}_{country}'
 
 
 class XYOsmData(InformalOsmDataInterface):

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -117,14 +117,14 @@ class OsmData():  # pylint: disable=too-few-public-methods
 
         # calc tiles
         if o_input_data.country:
-            self.calc_tiles_country(o_input_data)
+            o_geofabrik = self.calc_tiles_country(o_input_data)
         elif o_input_data.xy_coordinates:
             self.calc_tiles_xy(o_input_data)
 
         # calc border countries
         log.info('-' * 80)
         if o_input_data.country:
-            self.calc_border_countries_country(o_input_data)
+            self.calc_border_countries_country(o_input_data, o_geofabrik)
         elif o_input_data.xy_coordinates:
             self.calc_border_countries()
         # log border countries when and when not calculated to output the processed country(s)
@@ -158,6 +158,8 @@ class OsmData():  # pylint: disable=too-few-public-methods
         o_geofabrik = CountryGeofabrik(o_input_data.country)
         self.tiles = o_geofabrik.get_tiles_of_wanted_map()
 
+        return o_geofabrik
+
     def calc_tiles_xy(self, o_input_data):
         """
         option 2: input a x/y combinations as parameter, e.g. 134/88  or 133/88,130/100
@@ -169,7 +171,7 @@ class OsmData():  # pylint: disable=too-few-public-methods
         # find the tiles for  x/y combinations in the geofabrik json files
         self.tiles = o_geofabrik.get_tiles_of_wanted_map()
 
-    def calc_border_countries_country(self, o_input_data):
+    def calc_border_countries_country(self, o_input_data, o_geofabrik):
         """
         calculate the border countries for the given tiles when input is a country
         - if CLI/GUI input by user
@@ -178,7 +180,8 @@ class OsmData():  # pylint: disable=too-few-public-methods
             self.calc_border_countries()
         # set the to-be-processed country as border country
         else:
-            self.border_countries[o_input_data.country] = {}
+            for country in o_geofabrik.wanted_maps:
+                self.border_countries[country] = {}
 
     def calc_border_countries(self):
         """


### PR DESCRIPTION
## This PR…

- allows to give multiple countries to wahooMapsCreator via cli `-co malta,germany,liechtenstein`
- closes #189 

## Considerations and implementations

Changes in several files, doing country and X/Y in equal manner, unittests

## How to test

1.  `python -m wahoomc cli -co malta,germany,liechtenstein`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
