### PR TITLE
[BUGFIX] Do not use geofabrik .json file before geofabrik .json file has been downloaded

### DIFF
--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -146,10 +146,18 @@ def download_tooling():
 
     # download geofabrik json as this will be needed always
     # because of the .json file replacement by geofabrik
-    o_downloader = Downloader(24, False)
+    download_geofabrik_file_if_not_existing()
 
-    if o_downloader.should_geofabrik_file_be_downloaded():
-        o_downloader.download_geofabrik_file()
+
+def download_geofabrik_file_if_not_existing():
+    """
+    check geofabrik file if not existing
+    if the file does not exist, download geofabrik file
+    """
+    if not os.path.isfile(GEOFABRIK_PATH):
+        log.info('# Need to download geofabrik file')
+        download_file(GEOFABRIK_PATH,
+                      'https://download.geofabrik.de/index-v1.json')
 
 
 def get_latest_pypi_version():
@@ -190,6 +198,10 @@ class Downloader:
         self.max_days_old = max_days_old
         self.force_download = force_download
         self.border_countries = border_countries
+
+        # safety net if geofabrik file is not there
+        # OsmData=>process_input_of_the_tool does it "correctly"
+        download_geofabrik_file_if_not_existing()
 
         self.o_geofabrik_json = GeofabrikJson()
 

--- a/wahoomc/geofabrik.py
+++ b/wahoomc/geofabrik.py
@@ -46,7 +46,7 @@ class CountryGeofabrik(InformalGeofabrikInterface):
     def __init__(self, input):
         self.o_geofabrik_json = GeofabrikJson()
 
-        # input parameters
+        # get geofabrik country
         self.wanted_map = self.o_geofabrik_json.translate_id_no_to_geofabrik(
             input)
 
@@ -236,9 +236,10 @@ class XYGeofabrik(InformalGeofabrikInterface):
     """Geofabrik processing for X/Y coordinates"""
 
     def __init__(self, input):
-        # input parameters
-        self.wanted_map = input
         self.o_geofabrik_json = GeofabrikJson()
+
+        # already splitted pairs of xy-coordinates
+        self.wanted_map = input
 
     def get_tiles_of_wanted_map(self) -> str:
         """Overrides InformalGeofabrikInterface.get_tiles_of_wanted_map()"""

--- a/wahoomc/geofabrik.py
+++ b/wahoomc/geofabrik.py
@@ -25,7 +25,7 @@ class InformalGeofabrikInterface:
     border_countries = {}
     output = {}
 
-    o_geofabrik_json = GeofabrikJson()
+    o_geofabrik_json = None
 
     def get_tiles_of_wanted_map(self) -> str:
         """Get the relevant tiles for the wanted country or X/Y coordinate"""
@@ -44,6 +44,8 @@ class CountryGeofabrik(InformalGeofabrikInterface):
     """Geofabrik processing for countries"""
 
     def __init__(self, input):
+        self.o_geofabrik_json = GeofabrikJson()
+
         # input parameters
         self.wanted_map = self.o_geofabrik_json.translate_id_no_to_geofabrik(
             input)
@@ -236,6 +238,7 @@ class XYGeofabrik(InformalGeofabrikInterface):
     def __init__(self, input):
         # input parameters
         self.wanted_map = input
+        self.o_geofabrik_json = GeofabrikJson()
 
     def get_tiles_of_wanted_map(self) -> str:
         """Overrides InformalGeofabrikInterface.get_tiles_of_wanted_map()"""

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -16,8 +16,6 @@ from tkinter import ttk
 from wahoomc.geofabrik_json import GeofabrikJson
 from wahoomc.geofabrik_json import CountyIsNoGeofabrikCountry
 
-o_geofabrik_json = GeofabrikJson()
-
 
 def process_call_of_the_tool():
     """
@@ -156,7 +154,7 @@ def get_countries_of_continent_from_geofabrik(continent):
     returns all countries of a continent to be selected in UI
     """
     countries = []
-    for region, value in o_geofabrik_json.geofabrik_overview.items():
+    for region, value in GeofabrikJson().geofabrik_overview.items():
         try:
             if value['parent'] == continent:
                 countries.append(region)
@@ -206,7 +204,7 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
                 "Country and X/Y coordinates are given. Only one of both is allowed!")
         elif self.country:
             try:
-                self.country = o_geofabrik_json.translate_id_no_to_geofabrik(
+                self.country = GeofabrikJson().translate_id_no_to_geofabrik(
                     self.country)
                 return True
             except CountyIsNoGeofabrikCountry:
@@ -333,7 +331,7 @@ class ComboboxesEntryField(tk.Frame):  # pylint: disable=too-many-instance-attri
 
         # Comboboxes
         self.cb_continent = ttk.Combobox(
-            self, values=o_geofabrik_json.geofabrik_regions, state="readonly")
+            self, values=GeofabrikJson().geofabrik_regions, state="readonly")
         self.cb_continent.current(0)  # pre-select first entry in combobox
         self.cb_continent.bind("<<ComboboxSelected>>", self.callback_continent)
 

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -18,7 +18,7 @@ from wahoomc.file_directory_functions import move_content, write_json_file_gener
 from wahoomc.constants_functions import get_tooling_win_path, get_absolute_dir_user_or_repo
 from wahoomc.downloader import get_latest_pypi_version
 
-from wahoomc.constants import USER_WAHOO_MC
+from wahoomc.constants import GEOFABRIK_PATH, USER_WAHOO_MC
 from wahoomc.constants import USER_DL_DIR
 from wahoomc.constants import USER_MAPS_DIR
 from wahoomc.constants import USER_OUTPUT_DIR
@@ -90,6 +90,9 @@ def check_installation_of_required_programs():
     if not is_program_installed("java"):
         sys.exit(
             f"Java is not installed. {text_to_docu}")
+
+    if not os.path.isfile(GEOFABRIK_PATH):
+        sys.exit('Geofabrik file is not downloaded. Please create an issue:\n- https://github.com/treee111/wahooMapsCreator/issues"')
 
     if platform.system() == "Windows":
         if not os.path.exists(get_tooling_win_path(


### PR DESCRIPTION
## This PR…

- changes usages of the geofabrik .json file to not use the file during .py file initialization
- downloads the geofabrik .json at the beginning with all tooling stuff
- check if the geofabrik .json file is downloaded

## Considerations and implementations

screenshot of the error:
<img width="678" alt="grafik" src="https://user-images.githubusercontent.com/53038537/229313627-69374599-7de1-43e0-bb5e-ebce6db6ea6f.png">

## How to test

1. delete geofabrik.json file manually `/Users/<USERNAME>/wahooMapsCreatorData/_download/geofabrik.json`
2. `python -m wahoomc cli -h` or `python -m wahoomc gui`
3. it should work as normally

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
