### PR TITLE
[BUGFIX] install shapely and requests via conda instead of pip. For processing geofabrik.json with shapely on Windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -237,6 +237,23 @@
                 "-md",
                 "100"
             ]
+        },
+        {
+            "name": "co: france",
+            "type": "python",
+            "request": "launch",
+            "module": "wahoomc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-co",
+                "france",
+                "--bordercountries",
+                "--maxdays",
+                "30",
+                "--verbose"
+            ],
+            "justMyCode": false
         }
     ]
 }

--- a/docs/QUICKSTART_ANACONDA.md
+++ b/docs/QUICKSTART_ANACONDA.md
@@ -76,7 +76,7 @@ brew install osmosis
 1. Open terminal (macOS/Linux) or **Anaconda Prompt** (Windows, via Startmenu)
 2. Create a new Anaconda environment with needed packages
 ```
-conda create -n gdal-user python=3.10 geojson=2.5 gdal=3.4 pip --channel conda-forge --override-channels
+conda create -n gdal-user python=3.10 geojson=2.5 gdal=3.4 requests=2.28 shapely=1.8 pip --channel conda-forge --override-channels
 ```
 3. activate Anaconda environment with the command printed out (this needs to be done each time you want to use wahooMapsCreator maps)
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,6 @@ classifiers =
 [options]
 packages = wahoomc, wahoomc.init
 python_requires = >=3.10
-install_requires =
-    requests==2.28.*
-    shapely==1.8.*
 
 [options.package_data]
 wahoomc = resources/*.*, resources/*/*.*, resources/*/*/*.*, resources/*/*/*/*.*, tooling_win/*.*, tooling_win/*/*.*, tooling_win/*/*/*.*, tooling_win/*/*/*/*.*


### PR DESCRIPTION
## This PR…

- does install shapely and requests in the initial creation of the Anaconda environment instead of installing via pip when wahoomc is installed

wahoomc crashes silently when geofabrik file is calculated in this line. The problem seams to be shapely.
![grafik](https://user-images.githubusercontent.com/53038537/229368840-f974d7bd-f89b-4f2a-84d2-698f1746c638.png)

## Considerations and implementations

This situation was already present in all versions which have the option to calculate tiles via geofabrik .json instead of static .json files (i.e. since version 0.11.0).
Because geofabrik processing is the standard and only processing mode, it came up just now

see [faq](https://github.com/shapely/shapely/blob/main/FAQ.rst#i-installed-shapely-in-a-conda-environment-using-pip-why-doesnt-it-work) and [issue 1105](https://github.com/shapely/shapely/issues/1105#issuecomment-802856196)

## How to test

1. create Acaconda environment with
```
conda create -n gdal-user python=3.10 geojson=2.5 gdal=3.4 requests=2.28 shapely=1.8 pip --channel conda-forge --override-channels
```
3. run wahoomc for a country of your choice

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows

## Screenshots
When shapely is installed via pip
![grafik](https://user-images.githubusercontent.com/53038537/229367637-dd216218-d059-420a-8119-482b8319b871.png)

this error was already existing in v3.2.0:
![grafik](https://user-images.githubusercontent.com/53038537/229367772-6155de02-4474-499e-bf9f-573e1b2710e4.png)

and as well in the alpha versions of v4.0.0. v4.0.0a5:
![grafik](https://user-images.githubusercontent.com/53038537/229367847-4a21a6f8-6b15-4046-bf38-e34704e2bf87.png)

installing shapely via conda 
![grafik](https://user-images.githubusercontent.com/53038537/229367657-14e6340f-e0e4-4e63-a34a-311e8afdd41b.png)

works for v3.2.0:
![grafik](https://user-images.githubusercontent.com/53038537/229368144-021e1f80-80fa-4128-8860-208450c7fefe.png)

and alpha versions of v4.0.0. v4.0.0a5:
![grafik](https://user-images.githubusercontent.com/53038537/229367822-05612e20-2bfa-4cee-bb37-9669d0ce914b.png)
