### PR TITLE
[DEV] detail logging of subsprocesses, unify logging (tile progress, country config file)

### DIFF
--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -224,7 +224,7 @@ class TestConfigFile(unittest.TestCase):
         self.assertTrue(
             o_osm_maps.tags_are_identical_to_last_run(o_input_data.country))
 
-        country_config = fd_fct.read_json_file(os.path.join(
+        country_config = fd_fct.read_json_file_country_config(os.path.join(
             constants.USER_OUTPUT_DIR, o_input_data.country, ".config.json"))
 
         self.assertEqual(constants.VERSION, country_config["version_last_run"])

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -60,26 +60,24 @@ def create_empty_directories(parent_dir, tiles_from_json, border_countries):
         os.makedirs(outdir, exist_ok=True)
 
 
-def read_json_file(json_file_path):
+def read_json_file_country_config(json_file_path):
     """
-    read the tiles from the given json file
+    read the country config (of last run) from the given json file
     """
 
     log.debug('-' * 80)
-    log.debug('# Read json file')
+    log.debug('# Read country config json file')
 
-    with open(json_file_path, encoding="utf-8") as json_file:
-        tiles_from_json = json.load(json_file)
-        json_file.close()
-    if tiles_from_json == '':
+    country_config = read_json_file_generic(json_file_path)
+    if country_config == '':
         log.error('! Json file could not be opened.')
         sys.exit()
 
     log.debug(
-        '+ Use json file %s with %s tiles', json_file.name, len(tiles_from_json))
-    log.debug('+ Read json file: OK')
+        '+ Use country config file %s', json_file_path)
+    log.debug('+ Read country config json file: OK')
 
-    return tiles_from_json
+    return country_config
 
 
 def read_json_file_generic(json_file_path):

--- a/wahoomc/geofabrik.py
+++ b/wahoomc/geofabrik.py
@@ -39,6 +39,13 @@ class InformalGeofabrikInterface:
         """calculate bounding box based on geometry or X/Y combination"""
         pass
 
+    def log_tile(self, counter, all):
+        """
+        unified status logging for this class
+        """
+        log.info(
+            '(+ tile %s of %s) Find needed countries ', counter, all)
+
 
 class CountryGeofabrik(InformalGeofabrikInterface):
     """Geofabrik processing for countries"""
@@ -82,8 +89,7 @@ class CountryGeofabrik(InformalGeofabrikInterface):
         for tile in bbox_tiles:
             # Do progress indicator every 50 tiles
             if counter % 50 == 0:
-                log.info(
-                    'Processing tile %s of %s', counter, len(bbox_tiles)+1)
+                self.log_tile(counter, len(bbox_tiles)+1)
             counter += 1
 
             parent_added = 0
@@ -274,8 +280,7 @@ class XYGeofabrik(InformalGeofabrikInterface):
         for tile in bbox_tiles:
             # Do progress indicator every 50 tiles
             if counter % 50 == 0:
-                log.info(
-                    'Processing tile %s of %s', counter, len(bbox_tiles)+1)
+                self.log_tile(counter, len(bbox_tiles)+1)
             counter += 1
 
             parent_added = 0

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -64,7 +64,7 @@ def run_subprocess_and_log_output(cmd, error_message, cwd=""):
         process = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     else:
-        process = subprocess.Popen(
+        process = subprocess.Popen(  # pylint: disable=consider-using-with
             cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd)
 
     if error_message and process.wait() != 0:  # 0 means success

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -61,23 +61,30 @@ def run_subprocess_and_log_output(cmd, error_message, cwd=""):
     run given cmd-subprocess and issue error message if wished
     """
     if not cwd:
-        with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as process:
-            for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines
-                try:
-                    log.debug('subprocess:%r', line.decode("utf-8").strip())
-                except UnicodeDecodeError:
-                    log.debug('subprocess:%r', line.decode("latin-1").strip())
+        process = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     else:
-        with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd) as process:
-            for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines
-                try:
-                    log.debug('subprocess:%r', line.decode("utf-8").strip())
-                except UnicodeDecodeError:
-                    log.debug('subprocess:%r', line.decode("latin-1").strip())
+        process = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd)
 
     if error_message and process.wait() != 0:  # 0 means success
+        for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines
+            # print(line.rstrip())
+            try:
+                log.error('subprocess:%r', line.decode("utf-8").strip())
+            except UnicodeDecodeError:
+                log.error('subprocess:%r', line.decode("latin-1").strip())
+
         log.error(error_message)
         sys.exit()
+
+    else:
+        for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines
+            # print(line.rstrip())
+            try:
+                log.debug('subprocess:%r', line.decode("utf-8").strip())
+            except UnicodeDecodeError:
+                log.debug('subprocess:%r', line.decode("latin-1").strip())
 
 
 def get_timestamp_last_changed(file_path):

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -15,7 +15,7 @@ import shutil
 import logging
 
 # import custom python packages
-from wahoomc.file_directory_functions import read_json_file, create_empty_directories, write_json_file_generic
+from wahoomc.file_directory_functions import read_json_file_country_config, create_empty_directories, write_json_file_generic
 from wahoomc.constants_functions import translate_tags_to_keep, \
     get_tooling_win_path, get_tag_wahoo_xml_path, TagWahooXmlNotFoundError
 
@@ -826,7 +826,7 @@ class OsmMaps:
         tags_are_identical = True
 
         try:
-            country_config = read_json_file(os.path.join(
+            country_config = read_json_file_country_config(os.path.join(
                 USER_OUTPUT_DIR, country, ".config.json"))
             if not country_config["tags_last_run"] == translate_tags_to_keep(sys_platform=platform.system()) \
                     or not country_config["name_tags_last_run"] == translate_tags_to_keep(name_tags=True, sys_platform=platform.system()):
@@ -843,7 +843,7 @@ class OsmMaps:
         last_changed_is_identical = True
 
         try:
-            country_config = read_json_file(os.path.join(
+            country_config = read_json_file_country_config(os.path.join(
                 USER_OUTPUT_DIR, country, ".config.json"))
             if not country_config["changed_ts_map_last_run"] == get_timestamp_last_changed(self.o_osm_data.border_countries[country]['map_file']):
                 last_changed_is_identical = False

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -399,8 +399,7 @@ class OsmMaps:
 
             # create land.dbf, land.prj, land.shp, land.shx
             if not os.path.isfile(land_file) or self.o_osm_data.force_processing is True:
-                log.info(
-                    '+ Coordinates: %s,%s. (%s of %s)', tile["x"], tile["y"], tile_count, len(self.o_osm_data.tiles))
+                self.log_tile(tile["x"], tile["y"], tile_count)
                 cmd = ['ogr2ogr', '-overwrite', '-skipfailures']
                 # Try to prevent getting outside of the +/-180 and +/- 90 degrees borders. Normally the +/- 0.1 are there to prevent white lines at border borders.
                 if tile["x"] == 255 or tile["y"] == 255 or tile["x"] == 0 or tile["y"] == 0:
@@ -450,8 +449,7 @@ class OsmMaps:
             out_file_sea = os.path.join(USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}', 'sea.osm')
             if not os.path.isfile(out_file_sea) or self.o_osm_data.force_processing is True:
-                log.info(
-                    '+ Coordinates: %s,%s. (%s of %s)', tile["x"], tile["y"], tile_count, len(self.o_osm_data.tiles))
+                self.log_tile(tile["x"], tile["y"], tile_count)
                 with open(os.path.join(RESOURCES_DIR, 'sea.osm'), encoding="utf-8") as sea_file:
                     sea_data = sea_file.read()
 
@@ -494,8 +492,7 @@ class OsmMaps:
             for country, val in self.o_osm_data.border_countries.items():
                 if country not in tile['countries']:
                     continue
-                log.info(
-                    '+ Coordinates: %s,%s / %s (%s of %s)', tile["x"], tile["y"], country, tile_count, len(self.o_osm_data.tiles))
+                self.log_tile(tile["x"], tile["y"], tile_count, country)
                 out_file = os.path.join(USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}', f'split-{country}.osm.pbf')
                 out_file_names = os.path.join(USER_OUTPUT_DIR,
@@ -565,8 +562,7 @@ class OsmMaps:
         log.info('# Merge splitted tiles with land an sea')
         tile_count = 1
         for tile in self.o_osm_data.tiles:  # pylint: disable=too-many-nested-blocks
-            log.info(
-                '+ Coordinates: %s,%s (%s of %s)', tile["x"], tile["y"], tile_count, len(self.o_osm_data.tiles))
+            self.log_tile(tile["x"], tile["y"], tile_count)
 
             out_tile_dir = os.path.join(USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}')
@@ -665,8 +661,7 @@ class OsmMaps:
 
         tile_count = 1
         for tile in self.o_osm_data.tiles:
-            log.info(
-                '+ Coordinates: %s,%s (%s of %s)', tile["x"], tile["y"], tile_count, len(self.o_osm_data.tiles))
+            self.log_tile(tile["x"], tile["y"], tile_count)
 
             out_file_map = os.path.join(USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}.map')
@@ -856,3 +851,14 @@ class OsmMaps:
             last_changed_is_identical = False
 
         return last_changed_is_identical
+
+    def log_tile(self, tile_x, tile_y, tile_count, additional_info=''):
+        """
+        unified status logging for this class
+        """
+        if additional_info:
+            log.info('+ (tile %s of %s) Coordinates: %s,%s / %s', tile_count, len(self.o_osm_data.tiles), tile_x,
+                     tile_y, additional_info)
+        else:
+            log.info('+ (tile %s of %s) Coordinates: %s,%s',
+                     tile_count, len(self.o_osm_data.tiles), tile_x, tile_y)


### PR DESCRIPTION
## This PR…

- logs output of subprocesses
- unifies logging of tile progress (see screenshots)

## Screenshots

before:
<img width="673" alt="grafik" src="https://user-images.githubusercontent.com/53038537/229427981-7ecdf951-31ec-479f-9d9d-a81388522368.png">

after:
<img width="618" alt="grafik" src="https://user-images.githubusercontent.com/53038537/229428035-be8d36d3-8b13-4cb8-9c22-503a066a76ef.png">

## How to test

1. ...
2. ...

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
