### PR TITLE
[FEAT] Include waterway/canal in tag-wahoo-poi.xml

### DIFF
--- a/wahoomc/resources/tag_wahoo_adjusted/tag-wahoo-poi.xml
+++ b/wahoomc/resources/tag_wahoo_adjusted/tag-wahoo-poi.xml
@@ -80,6 +80,7 @@
 
     <osm-tag key="landuse" value="forest" zoom-appear="8" />
 
+    <osm-tag key="waterway" value="canal" zoom-appear="8"/>
     <osm-tag key="waterway" value="stream" zoom-appear="8"/>
     <osm-tag key="waterway" value="river" zoom-appear="8"/>
     <osm-tag key="waterway" value="riverbank" zoom-appear="8"/>


### PR DESCRIPTION
Fehlenden Tag 'canal' eingefügt. Hinweis von Michael
Der Tag ist in der Datei 'tag-wahoo.xml' enthalten, nicht aber in 'tag-wahoo-poi.xml'.

Das Beispiel war dieser Kanal:
https://www.openstreetmap.org/way/213119956