### PR TITLE
[FEAT] Include waterway/stream in tags-to-keep.json

### DIFF
--- a/wahoomc/resources/tags-to-keep.json
+++ b/wahoomc/resources/tags-to-keep.json
@@ -81,7 +81,8 @@
             "canal",
             "drain",
             "river",
-            "riverbank"
+            "riverbank",
+            "stream"
         ],
         "wood": "deciduous"
     },


### PR DESCRIPTION
## This PR…

- closes #200
- include [waterway/stream](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Dstream) OSM objects in default tags-to-keep.json

## How to test

1. ...
2. ...

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
