### PR TITLE
[FEAT] option to choose source for contour lines: view1 (standard) and srtm1

### DIFF
--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -62,6 +62,9 @@ def process_call_of_the_tool():
     # calculate contour lines
     options_args.add_argument('-con', '--contour', action='store_true',
                               help="process contour lines (elevation data)")
+    # use srtm1 for contour lines
+    options_args.add_argument('-srtm1', '--use_srtm1', action='store_true',
+                              help="use srtm1 as source for contour lines (elevation data)")
     # Force download of source maps and the land shape file
     # If False use Max_Days_Old to check for expired maps
     # If True force redownloading of maps and landshape
@@ -104,6 +107,7 @@ def process_call_of_the_tool():
 
     o_input_data.process_border_countries = args.bordercountries
     o_input_data.contour = args.contour
+    o_input_data.use_srtm1 = args.use_srtm1
 
     o_input_data.force_download = args.forcedownload
     o_input_data.force_processing = args.forceprocessing
@@ -185,11 +189,12 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
         self.force_processing = False
         self.process_border_countries = True
         self.contour = False
-        self.save_cruiser = False
+        self.use_srtm1 = False
 
         self.tag_wahoo_xml = "tag-wahoo-poi.xml"
-
         self.zip_folder = False
+        self.save_cruiser = False
+
         self.verbose = False
 
     def is_required_input_given_or_exit(self, issue_message):
@@ -301,6 +306,7 @@ class GuiInput(tk.Tk):
         self.o_input_data.force_processing = tab1.third.checkb_processing_val.get()
         self.o_input_data.process_border_countries = tab1.third.checkb_border_countries_val.get()
         self.o_input_data.contour = tab1.third.checkb_contour_val.get()
+        self.o_input_data.use_srtm1 = tab1.third.checkb_srtm1_val.get()
 
         self.o_input_data.save_cruiser = tab2.first.checkb_save_cruiser_val.get()
         self.o_input_data.zip_folder = tab2.first.checkb_zip_folder_val.get()
@@ -397,13 +403,15 @@ class CheckbuttonsTab1(tk.Frame):
 
         self.checkb_border_countries_val = create_checkbox(self, oInputData.process_border_countries,
                                                            "Process border countries", 0)
-        self.checkb_contour_val = create_checkbox(self, oInputData.verbose,
+        self.checkb_contour_val = create_checkbox(self, oInputData.contour,
                                                   "process contour lines (elevation data)", 1)
+        self.checkb_srtm1_val = create_checkbox(self, oInputData.use_srtm1,
+                                                "use srtm1 as source for contour lines (elevation data)", 2)
 
         self.chk_force_download.grid(
-            column=0, row=2, sticky=tk.W, padx=15, pady=5)
+            column=0, row=3, sticky=tk.W, padx=15, pady=5)
         self.checkb_processing_val = create_checkbox(self, oInputData.force_processing,
-                                                     "Force processing", 3)
+                                                     "Force processing", 4)
 
 
 class Buttons(tk.Frame):

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -83,7 +83,7 @@ def run(run_level):
 
         # Generate elevation
         if o_input_data.contour:
-            o_osm_maps.generate_elevation()
+            o_osm_maps.generate_elevation(o_input_data.use_srtm1)
 
         # Split filtered country files to tiles
         o_osm_maps.split_filtered_country_files_to_tiles()

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -522,7 +522,7 @@ class OsmMaps:
 
         log.info('+ Generate sea for each coordinate: OK')
 
-    def generate_elevation(self):
+    def generate_elevation(self, use_srtm1):
         """
         Generate contour lines for all tiles
         """
@@ -541,6 +541,15 @@ class OsmMaps:
             # example elevation filename: elevation_lon14.06_15.47lat35.46_36.60_view1,view3.osm
             out_file_elevation_existing = glob.glob(os.path.join(
                 USER_OUTPUT_DIR, str(tile["x"]), str(tile["y"]), 'elevation*.osm'))
+
+            # use view1 as default source and srtm1 if wished by the user
+            # view1 offers better quality in general apart fro some places
+            # where srtm1 is the better choice
+            if use_srtm1:
+                elevation_source = '--source=srtm1,view1,view3,srtm3'
+            else:
+                elevation_source = '--source=view1,view3,srtm3'
+
             # check for already existing elevation .osm file (the ones matched via glob)
             if not (len(out_file_elevation_existing) == 1 and os.path.isfile(out_file_elevation_existing[0])) \
                     or self.o_osm_data.force_processing is True:
@@ -549,7 +558,7 @@ class OsmMaps:
                 cmd = ['phyghtmap']
                 cmd.append('-a ' + f'{tile["left"]}' + ':' + f'{tile["bottom"]}' +
                            ':' + f'{tile["right"]}' + ':' + f'{tile["top"]}')
-                cmd.extend(['-o', f'{out_file_elevation}', '-s 10', '-c 100,50', '--source=srtm1,view1,view3,srtm3',
+                cmd.extend(['-o', f'{out_file_elevation}', '-s 10', '-c 100,50', elevation_source,
                             '--jobs=8', '--viewfinder-mask=1', '--start-node-id=20000000000',
                             '--max-nodes-per-tile=0', '--start-way-id=2000000000', '--write-timestamp',
                             '--no-zero-contour', '--hgtdir=' + hgt_path])


### PR DESCRIPTION
## This PR…

- lets the user choose srtm1 as source for contour lines

## Considerations and implementations

see https://github.com/treee111/wahooMapsCreator/issues/145#issuecomment-1536715860

## How to test

1. ...
2. ...

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
