### PR TITLE
Add prototype timing of duration and process time used, request for comments

### DIFF
--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -5,6 +5,7 @@ executable file to create up-to-date map-files for the Wahoo ELEMNT and Wahoo EL
 
 # import official python packages
 import logging
+import time
 
 # import custom python packages
 from wahoomc.input import process_call_of_the_tool, cli_init
@@ -63,6 +64,9 @@ def run(run_level):
         elif o_input_data.xy_coordinates:
             o_osm_data = XYOsmData(o_input_data)
 
+        log = logging.getLogger('main-logger')
+        process_time = time.process_time()
+        wall_clock = time.perf_counter()
         # Check for not existing or expired files. Mark for download, if dl is needed
         o_osm_data.process_input_of_the_tool()
         o_downloader = o_osm_data.get_downloader()
@@ -102,6 +106,8 @@ def run(run_level):
         # Make Cruiser map files zip file
         if o_input_data.save_cruiser is True:
             o_osm_maps.make_and_zip_files('.map', o_input_data.zip_folder)
+
+        log.info('Total time %.5f' % (time.process_time() - process_time) + ', %.5f' % (time.perf_counter() - wall_clock))
 
     # run was successful --> write config file
     write_config_file()

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -88,7 +88,7 @@ def run(run_level):
         # Split filtered country files to tiles
         o_osm_maps.split_filtered_country_files_to_tiles()
 
-        # Merge splitted tiles with land an sea
+        # Merge splitted tiles with land and sea
         o_osm_maps.merge_splitted_tiles_with_land_and_sea(
             o_input_data.process_border_countries)
 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -548,6 +548,8 @@ class OsmMaps:
 
         hgt_path = os.path.join(USER_DL_DIR, 'hgt')
 
+        process_time = time.process_time()
+        wall_clock = time.perf_counter()
         tile_count = 1
         for tile in self.o_osm_data.tiles:
             out_file_elevation = os.path.join(
@@ -568,8 +570,9 @@ class OsmMaps:
             # check for already existing elevation .osm file (the ones matched via glob)
             if not (len(out_file_elevation_existing) == 1 and os.path.isfile(out_file_elevation_existing[0])) \
                     or self.o_osm_data.force_processing is True:
-                log.info(
-                    '+ Coordinates: %s,%s. (%s of %s)', tile["x"], tile["y"], tile_count, len(self.o_osm_data.tiles))
+                self.log_tile(tile["x"], tile["y"], tile_count)
+                tile_process_time = time.process_time()
+                tile_wall_clock = time.perf_counter()
                 cmd = ['phyghtmap']
                 cmd.append('-a ' + f'{tile["left"]}' + ':' + f'{tile["bottom"]}' +
                            ':' + f'{tile["right"]}' + ':' + f'{tile["top"]}')
@@ -582,10 +585,11 @@ class OsmMaps:
 
                 run_subprocess_and_log_output(
                     cmd, f'! Error in phyghtmap with tile: {tile["x"]},{tile["y"]}. Win_macOS/elevation')
+                self.log_tile(tile["x"], tile["y"], tile_count, 'done, took %.5f ' % (time.perf_counter()-tile_wall_clock))
 
             tile_count += 1
 
-        log.info('+ Generate contour lines for each coordinate: OK')
+        log.info('+ Generate contour lines for each coordinate: OK, took ' + '%.5f' % (time.process_time()-process_time) + ', %.5f' % (time.perf_counter()-wall_clock))
 
     def split_filtered_country_files_to_tiles(self):
         """

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -674,9 +674,13 @@ class OsmMaps:
 
         log.info('-' * 80)
         log.info('# Merge splitted tiles with land, elevation, and sea')
+        process_time = time.process_time();
+        wall_clock = time.perf_counter();
         tile_count = 1
         for tile in self.o_osm_data.tiles:  # pylint: disable=too-many-nested-blocks
             self.log_tile(tile["x"], tile["y"], tile_count)
+            tile_process_time = time.process_time()
+            tile_wall_clock = time.perf_counter()
 
             out_tile_dir = os.path.join(USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}')
@@ -734,9 +738,10 @@ class OsmMaps:
             run_subprocess_and_log_output(
                 cmd, f'! Error in Osmosis with tile: {tile["x"]},{tile["y"]}')
 
+            self.log_tile(tile["x"], tile["y"], tile_count, ' took %.5f' % (time.perf_counter() - tile_wall_clock))
             tile_count += 1
 
-        log.info('+ Merge splitted tiles with land, elevation, and sea: OK')
+        log.info('+ Merge splitted tiles with land, elevation, and sea: OK, took ' + '%.5f' % (time.process_time()-process_time) + ', %.5f' % (time.perf_counter()-wall_clock))
 
     def sort_osm_files(self, tile):
         """
@@ -780,9 +785,13 @@ class OsmMaps:
         if int(threads) < 1:
             threads = 1
 
+        process_time = time.process_time();
+        wall_clock = time.perf_counter();
         tile_count = 1
         for tile in self.o_osm_data.tiles:
             self.log_tile(tile["x"], tile["y"], tile_count)
+            tile_process_time = time.process_time()
+            tile_wall_clock = time.perf_counter()
 
             out_file_map = os.path.join(USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}.map')
@@ -836,9 +845,10 @@ class OsmMaps:
             with open(out_file_map + '.lzma.17', mode='wb') as tile_present_file:
                 tile_present_file.close()
 
+            self.log_tile(tile["x"], tile["y"], tile_count, ' took %.5f' % (time.perf_counter() - tile_wall_clock))
             tile_count += 1
 
-        log.info('+ Creating .map files for tiles: OK')
+        log.info('+ Creating .map files for tiles: OK, took ' + '%.5f' % (time.process_time()-process_time) + ', %.5f' % (time.perf_counter()-wall_clock))
 
     def make_and_zip_files(self, extension, zip_folder):
         """
@@ -855,6 +865,8 @@ class OsmMaps:
         log.info('-' * 80)
         log.info('# Create: %s files', extension)
         log.info('+ Country: %s', self.o_osm_data.country_name)
+        process_time = time.process_time();
+        wall_clock = time.perf_counter();
 
         # Check for us/utah etc names
         try:
@@ -905,7 +917,7 @@ class OsmMaps:
 
             log.info('+ Zip %s files: OK', extension)
 
-        log.info('+ Create %s files: OK', extension)
+        log.info('+ Create %s files: OK, took %.5f, %.5f', extension, time.process_time()-process_time, time.perf_counter()-wall_clock)
 
     def copy_to_dst(self, extension, src, dst):
         """

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -317,8 +317,8 @@ class OsmMaps:
         log.info('# Filter tags from country osm.pbf files')
 
 
-        process_time = time.process_time();
-        wall_clock = time.perf_counter();
+        process_time = time.process_time()
+        wall_clock = time.perf_counter()
         for key, val in self.o_osm_data.border_countries.items():
             # evaluate contry directory, create if not exists
             country_dir = os.path.join(USER_OUTPUT_DIR, key)
@@ -437,8 +437,8 @@ class OsmMaps:
         log.info('-' * 80)
         log.info('# Generate land for each coordinate')
 
-        process_time = time.process_time();
-        wall_clock = time.perf_counter();
+        process_time = time.process_time()
+        wall_clock = time.perf_counter()
         tile_count = 1
         for tile in self.o_osm_data.tiles:
             land_file = os.path.join(USER_OUTPUT_DIR,
@@ -496,8 +496,8 @@ class OsmMaps:
         log.info('-' * 80)
         log.info('# Generate sea for each coordinate')
 
-        process_time = time.process_time();
-        wall_clock = time.perf_counter();
+        process_time = time.process_time()
+        wall_clock = time.perf_counter()
         tile_count = 1
         for tile in self.o_osm_data.tiles:
             out_file_sea = os.path.join(USER_OUTPUT_DIR,
@@ -594,8 +594,8 @@ class OsmMaps:
 
         log.info('-' * 80)
         log.info('# Split filtered country files to tiles')
-        process_time = time.process_time();
-        wall_clock = time.perf_counter();
+        process_time = time.process_time()
+        wall_clock = time.perf_counter()
         tile_count = 1
         for tile in self.o_osm_data.tiles:
 
@@ -674,8 +674,8 @@ class OsmMaps:
 
         log.info('-' * 80)
         log.info('# Merge splitted tiles with land, elevation, and sea')
-        process_time = time.process_time();
-        wall_clock = time.perf_counter();
+        process_time = time.process_time()
+        wall_clock = time.perf_counter()
         tile_count = 1
         for tile in self.o_osm_data.tiles:  # pylint: disable=too-many-nested-blocks
             self.log_tile(tile["x"], tile["y"], tile_count)
@@ -785,8 +785,8 @@ class OsmMaps:
         if int(threads) < 1:
             threads = 1
 
-        process_time = time.process_time();
-        wall_clock = time.perf_counter();
+        process_time = time.process_time()
+        wall_clock = time.perf_counter()
         tile_count = 1
         for tile in self.o_osm_data.tiles:
             self.log_tile(tile["x"], tile["y"], tile_count)
@@ -865,8 +865,8 @@ class OsmMaps:
         log.info('-' * 80)
         log.info('# Create: %s files', extension)
         log.info('+ Country: %s', self.o_osm_data.country_name)
-        process_time = time.process_time();
-        wall_clock = time.perf_counter();
+        process_time = time.process_time()
+        wall_clock = time.perf_counter()
 
         # Check for us/utah etc names
         try:

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -437,12 +437,16 @@ class OsmMaps:
         log.info('-' * 80)
         log.info('# Generate land for each coordinate')
 
+        process_time = time.process_time();
+        wall_clock = time.perf_counter();
         tile_count = 1
         for tile in self.o_osm_data.tiles:
             land_file = os.path.join(USER_OUTPUT_DIR,
                                      f'{tile["x"]}', f'{tile["y"]}', 'land.shp')
             out_file_land1 = os.path.join(USER_OUTPUT_DIR,
                                           f'{tile["x"]}', f'{tile["y"]}', 'land')
+            tile_process_time = time.process_time()
+            tile_wall_clock = time.perf_counter()
 
             # create land.dbf, land.prj, land.shp, land.shx
             if not os.path.isfile(land_file) or self.o_osm_data.force_processing is True:
@@ -479,9 +483,10 @@ class OsmMaps:
 
                 run_subprocess_and_log_output(
                     cmd, f'! Error creating land.osm for tile: {tile["x"]},{tile["y"]}')
+            self.log_tile(tile["x"], tile["y"], tile_count, 'took %.5f' % (time.perf_counter() - tile_wall_clock))
             tile_count += 1
 
-        log.info('+ Generate land for each coordinate: OK')
+        log.info('+ Generate land for each coordinate: OK, took ' + '%.5f' % (time.process_time() - process_time) + ', %.5f' % (time.perf_counter()-wall_clock))
 
     def generate_sea(self):
         """
@@ -491,10 +496,15 @@ class OsmMaps:
         log.info('-' * 80)
         log.info('# Generate sea for each coordinate')
 
+        process_time = time.process_time();
+        wall_clock = time.perf_counter();
         tile_count = 1
         for tile in self.o_osm_data.tiles:
             out_file_sea = os.path.join(USER_OUTPUT_DIR,
                                         f'{tile["x"]}', f'{tile["y"]}', 'sea.osm')
+            tile_process_time = time.process_time()
+            tile_wall_clock = time.perf_counter()
+
             if not os.path.isfile(out_file_sea) or self.o_osm_data.force_processing is True:
                 self.log_tile(tile["x"], tile["y"], tile_count)
                 with open(os.path.join(RESOURCES_DIR, 'sea.osm'), encoding="utf-8") as sea_file:
@@ -522,9 +532,10 @@ class OsmMaps:
 
                     with open(out_file_sea, mode='w', encoding="utf-8") as output_file:
                         output_file.write(sea_data)
+            self.log_tile(tile["x"], tile["y"], tile_count, 'took %.5f' % (time.perf_counter() - tile_wall_clock))
             tile_count += 1
 
-        log.info('+ Generate sea for each coordinate: OK')
+        log.info('+ Generate sea for each coordinate: OK, took ' + '%.5f' % (time.process_time() - process_time) + ', %.5f' % (time.perf_counter()-wall_clock))
 
     def generate_elevation(self, use_srtm1):
         """
@@ -650,9 +661,7 @@ class OsmMaps:
                     run_subprocess_and_log_output(
                         cmd, '! Error in Osmosis with country: {country}. macOS/out_file_names')
 
-                # Need to figure out how to do the logging via the log_tile method, and how to pass clock sources
-                #log.info('Took %.5f ' % (time.perf_counter() - tile_wall_clock))
-                log.info('+ Coordinates: %s,%s / %s (%s of %s), took %.5f', tile["x"], tile["y"], country, tile_count, len(self.o_osm_data.tiles), (time.perf_counter() - tile_wall_clock))
+                self.log_tile(tile["x"], tile["y"], tile_count, country + ' done, took %.5f' % (time.perf_counter() - tile_wall_clock))
 
             tile_count += 1
 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -648,11 +648,11 @@ class OsmMaps:
 
     def merge_splitted_tiles_with_land_and_sea(self, process_border_countries):
         """
-        Merge splitted tiles with land elevation and sea
+        Merge splitted tiles with land, elevation, and sea
         """
 
         log.info('-' * 80)
-        log.info('# Merge splitted tiles with land, elevation and sea')
+        log.info('# Merge splitted tiles with land, elevation, and sea')
         tile_count = 1
         for tile in self.o_osm_data.tiles:  # pylint: disable=too-many-nested-blocks
             self.log_tile(tile["x"], tile["y"], tile_count)
@@ -715,7 +715,7 @@ class OsmMaps:
 
             tile_count += 1
 
-        log.info('+ Merge splitted tiles with land, elevation and sea: OK')
+        log.info('+ Merge splitted tiles with land, elevation, and sea: OK')
 
     def sort_osm_files(self, tile):
         """


### PR DESCRIPTION
**Thank you for your contribution!** 🙌

To get it merged faster, please use this template and replace as many "{...}" as possible and kindly review the checklist below.

## This PR is just a prototype suggestion, to add some logging of the duration of the various steps

This PR is just a prototype suggestion, to ask for feedback, to add some logging of the duration of the various steps

- {...}

## Considerations and implementations

I mainly want to have some logging of the duration of the various steps, so I can compare performance
on various machines.
Having some logging of time taken for each small steps, also gives guidance on how long it will take overall.

Unsure if it makes sense to log the process time, since Python seems to be mainly used to start other processes,
and that does not seem to count against the process time.

Also need to figure out how to best format the logging, so it looks nice and is understandable.

The PR is not meant for merging as of now, it is mainly a request for some feedback if you think this would
be an approach to get logging of time used.

## How to test

Run with a couple of tiles, to see the output.

Examples
INFO:# Filter tags from country osm.pbf files
INFO:+ Filtering unwanted map objects out of map of norway
INFO:+ Filter tags from country osm.pbf files: OK, took 0.00582, 163.16366

INFO:# Split filtered country files to tiles
INFO:+ Coordinates: 131,74 / norway (1 of 2)
INFO:+ Coordinates: 131,74 / norway (1 of 2), took 50.71666
INFO:+ Coordinates: 131,75 / norway (2 of 2)
INFO:+ Coordinates: 131,75 / norway (2 of 2), took 50.26628
INFO:+ Split filtered country files to tiles: OK, took 0.00818, 100.98379


## Pull Request Checklist
- [X ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [ ] Commits (and commit-messages) are understandable
- [ X] Tested with macOS / Linux
- [ ] Tested with Windows
