### PR TITLE
[FIX] Use process.run instead of process.Popen, to avoid deadlock

### DIFF
--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -40,30 +40,24 @@ def run_subprocess_and_log_output(cmd, error_message, cwd=""):
     run given cmd-subprocess and issue error message if wished
     """
     if not cwd:
-        process = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    else:
-        process = subprocess.Popen(  # pylint: disable=consider-using-with
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd)
+        process = subprocess.run(
+            cmd, capture_output=True, text=True, encoding="utf-8")
 
-    if error_message and process.wait() != 0:  # 0 means success
-        for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines
-            # print(line.rstrip())
-            try:
-                log.error('subprocess:%r', line.decode("utf-8").strip())
-            except UnicodeDecodeError:
-                log.error('subprocess:%r', line.decode("latin-1").strip())
+    else:
+        process = subprocess.run(  # pylint: disable=consider-using-with
+            cmd, capture_output=True, cwd=cwd, text=True, encoding="utf-8")
+
+
+    if error_message and process.returncode != 0:  # 0 means success
+        line = process.stderr
+        log.error('subprocess:%s', line)
 
         log.error(error_message)
         sys.exit()
 
     else:
-        for line in iter(process.stdout.readline, b''):  # b'\n'-separated lines
-            # print(line.rstrip())
-            try:
-                log.debug('subprocess:%r', line.decode("utf-8").strip())
-            except UnicodeDecodeError:
-                log.debug('subprocess:%r', line.decode("latin-1").strip())
+        line = process.stdout  # b'\n'-separated lines
+        log.debug('subprocess:%s', line)
 
 
 def get_timestamp_last_changed(file_path):

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -41,23 +41,24 @@ def run_subprocess_and_log_output(cmd, error_message, cwd=""):
     """
     if not cwd:
         process = subprocess.run(
-            cmd, capture_output=True, text=True, encoding="utf-8")
+            cmd, capture_output=True, text=True, encoding="utf-8", check=False)
 
     else:
         process = subprocess.run(  # pylint: disable=consider-using-with
-            cmd, capture_output=True, cwd=cwd, text=True, encoding="utf-8")
+            cmd, capture_output=True, cwd=cwd, text=True, encoding="utf-8", check=False)
 
 
     if error_message and process.returncode != 0:  # 0 means success
-        line = process.stderr
-        log.error('subprocess:%s', line)
+        log.error('subprocess error output:')
+        if process.stderr:
+            log.error(process.stderr)
 
         log.error(error_message)
         sys.exit()
 
-    else:
-        line = process.stdout  # b'\n'-separated lines
-        log.debug('subprocess:%s', line)
+    elif process.stdout:
+        log.debug('subprocess debug output:')
+        log.debug(process.stdout)
 
 
 def get_timestamp_last_changed(file_path):


### PR DESCRIPTION
## This PR…

- Fix deadlock when calling osmosis as subprocess, this should fix issue #205

## Considerations and implementations

The current use of subprocess.Popen always causes a hang due to deadlock when generating the 133/75 tile, for example.
The hang is when running the osmosis command, which produces quite a bit of output for this tile.

See idential issue: https://stackoverflow.com/questions/39477003/python-subprocess-popen-hanging

## How to test

1. python -m wahoomc cli -xy 133/75 -nbc -z
2. With the changes, observe that it works fine. Without the changes, it will get stuck on "Creating .map files for tiles" step for the tile.

## Pull Request Checklist
- [X] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [X] Commits (and commit-messages) are understandable
- [X] Tested with macOS / Linux
- [ ] Tested with Windows
