### PR TITLE
[FIX] let osmosis use HDD instead of RAM when creating .map files

### DIFF
--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -578,7 +578,7 @@ class OsmMaps:
             # Non-Windows
             else:
                 cmd = ['osmosis', '--rb', merged_file,
-                       '--mw', 'file='+out_file_map]
+                       '--mw', 'file='+out_file_map, 'type=hd']
 
             cmd.append(
                 f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')


### PR DESCRIPTION
## This PR…

- fixes https://github.com/treee111/wahooMapsCreator/issues/145#issuecomment-1537518024
- by using HDD for buffering or whatever with parameter "type=hd". Might be a little slower... but no more crash.

## Considerations and implementations
issue report: https://github.com/treee111/wahooMapsCreator/issues/145#issuecomment-1537488604
solution: https://github.com/treee111/wahooMapsCreator/issues/145#issuecomment-1537518024

## How to test

1. run `python -m wahoomc cli -xy 134/90 -con -srtm1` in branch develop
2. run it with this change applied

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
