### PR TITLE
[FIX] include elevation data only if requested by the user, i.e. if `-con` is given

### DIFF
--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -90,7 +90,7 @@ def run(run_level):
 
         # Merge splitted tiles with land an sea
         o_osm_maps.merge_splitted_tiles_with_land_and_sea(
-            o_input_data.process_border_countries)
+            o_input_data.process_border_countries, o_input_data.contour)
 
         # Creating .map files
         o_osm_maps.create_map_files(o_input_data.save_cruiser,

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -647,9 +647,10 @@ class OsmMaps:
 
         log.info('+ Split filtered country files to tiles: OK')
 
-    def merge_splitted_tiles_with_land_and_sea(self, process_border_countries):
+    def merge_splitted_tiles_with_land_and_sea(self, process_border_countries, contour):
         """
         Merge splitted tiles with land elevation and sea
+        - elevation data only if requested
         """
 
         log.info('-' * 80)
@@ -702,9 +703,10 @@ class OsmMaps:
                 cmd.extend(
                     ['--rx', 'file='+land, '--s', '--m'])
 
-            for elevation in elevation_files:
-                cmd.extend(
-                    ['--rx', 'file='+elevation, '--s', '--m'])
+            if contour:
+                for elevation in elevation_files:
+                    cmd.extend(
+                        ['--rx', 'file='+elevation, '--s', '--m'])
 
             cmd.extend(
                 ['--rx', 'file='+os.path.join(out_tile_dir, 'sea.osm'), '--s', '--m'])


### PR DESCRIPTION
## This PR…

- only includes elevation data into the maps if requested by the user, i.e. if `-con` is given

## Considerations and implementations

If elevation data was present per tile (from a run earlier), they are included into the generated maps even if not requested - i.e. `-con `is not given.
It came up when noticing that unittests fail. Because that makes the generated files from unittests differ from the static files in the repo because they are not generated with elevation data.

## How to test

0. have a VTM-theme which displays contour lines
1. run with `-con` and check for contour lines with cruiser - should be present
2. run without `-con` and check for contour lines with cruiser - should not be present

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
