### PR TITLE
[DEV] remove deprecated linting settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,12 +9,6 @@
     "python.testing.pytestEnabled": false,
     // "python.testing.nosetestsEnabled": false,
     "python.testing.unittestEnabled": true,
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true,
-    // "python.linting.pylintUseMinimalCheckers": false,
-    // "python.linting.pylintArgs": [
-    //     "--disable=line-too-long"
-    // ],
     "editor.formatOnSave": true,
     "python.analysis.indexing": true
 }


### PR DESCRIPTION
## This PR…

- removes the deprecated `python.linting` settings from `/.vscode/settings.json`
- also removes the commented-out `python.linting` settings from `/.vscode/settings.json`

## Considerations and implementations

![grafik](https://github.com/treee111/wahooMapsCreator/assets/53038537/6da7d84e-80a4-4c68-9ee6-7a17cae1985c)

## How to test

1. start VSCode and check for the popup message

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
