### PR TITLE
[FEAT] Use proper tool name in error message, reference Osmium or osmconvert

### DIFF
--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -614,7 +614,7 @@ class OsmMaps:
                     cmd.append('-o='+out_file)
 
                     run_subprocess_and_log_output(
-                        cmd, f'! Error in Osmosis with country: {country}. Win/out_file')
+                        cmd, f'! Error in osmconvert with country: {country}. Win/out_file')
 
                     cmd = [self.osmconvert_path,
                            '-v', '--hash-memory=2500']
@@ -626,7 +626,7 @@ class OsmMaps:
                     cmd.append('-o='+out_file_names)
 
                     run_subprocess_and_log_output(
-                        cmd, '! Error in Osmosis with country: {country}. Win/out_file_names')
+                        cmd, '! Error in osmconvert with country: {country}. Win/out_file_names')
 
                 # Non-Windows
                 else:
@@ -639,7 +639,7 @@ class OsmMaps:
                     cmd.extend(['--overwrite'])
 
                     run_subprocess_and_log_output(
-                        cmd, '! Error in Osmosis with country: {country}. macOS/out_file')
+                        cmd, '! Error in Osmium with country: {country}. macOS/out_file')
 
                     cmd = ['osmium', 'extract']
                     cmd.extend(
@@ -650,7 +650,7 @@ class OsmMaps:
                     cmd.extend(['--overwrite'])
 
                     run_subprocess_and_log_output(
-                        cmd, '! Error in Osmosis with country: {country}. macOS/out_file_names')
+                        cmd, '! Error in Osmium with country: {country}. macOS/out_file_names')
 
                 self.log_tile_debug(tile["x"], tile["y"], tile_count, f'{country} {timings_tile.stop_and_return()}')
 


### PR DESCRIPTION
## This PR…

- Trivial fix for error message being emitted when the extract phase fails.

## Considerations and implementations

I assume this is a left over, copy/paste error, or that the osmosis was used for this phase earlier.
Tidy up the message, so it is clear where osmium is used and where osmosis is used.

Also wonder a bit why osmconvert is used on Windows, and not Osmium, I would assume we prefer
to use the same tools on Windows and Linux, to keep things simple and similar. But that is not relevant for this PR.

## How to test

1. ...
2. ...

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
