### PR TITLE
[DEV] use `pyhgtmap` instead of `phyghtmap` for generating contour lines

### DIFF
--- a/conda_env/gdal-dev-pyh.yml
+++ b/conda_env/gdal-dev-pyh.yml
@@ -1,0 +1,23 @@
+name: gdal-dev-pyh
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - gdal=3.6.*
+  - requests=2.28.*
+  - pylint=2.15.*
+  - geojson=2.5.*
+  - shapely=1.8.*
+  - osmium-tool=1.15.*
+  - bs4=4.11.*
+  - lxml=4.9.*
+  - matplotlib=3.4.3
+  - autopep8=2.0.*
+  - mock
+  - twine
+  - pip
+  - vulture
+  - pydeps
+  - pip:
+      - build
+      - pyhgtmap

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifiers =
 [options]
 packages = wahoomc, wahoomc.init
 python_requires = >=3.10
+install_requires =
+    pyhgtmap
 
 [options.package_data]
 wahoomc = resources/*.*, resources/*/*.*, resources/*/*/*.*, resources/*/*/*/*.*, tooling_win/*.*, tooling_win/*/*.*, tooling_win/*/*/*.*, tooling_win/*/*/*/*.*

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -344,7 +344,9 @@ class OsmMaps:
                     or self.o_osm_data.force_processing is True:
                 self.log_tile_info(tile["x"], tile["y"], tile_count)
                 timings_tile = Timings()
-                cmd = ['phyghtmap']
+                # TODO: remove chapter wahooMapsCreator/docs/QUICKSTART_ANACONDA.md#additional-programs-for-generating-contour-lines
+                # when switching to pyhgtmap
+                cmd = ['pyhgtmap']
                 cmd.append('-a ' + f'{tile["left"]}' + ':' + f'{tile["bottom"]}' +
                            ':' + f'{tile["right"]}' + ':' + f'{tile["top"]}')
                 cmd.extend(['-o', f'{out_file_elevation}', '-s 10', '-c 100,50', elevation_source,
@@ -355,7 +357,7 @@ class OsmMaps:
                 cmd.append('--earthexplorer-password=' + password)
 
                 run_subprocess_and_log_output(
-                    cmd, f'! Error in phyghtmap with tile: {tile["x"]},{tile["y"]}. Win_macOS/elevation')
+                    cmd, f'! Error in pyhgtmap with tile: {tile["x"]},{tile["y"]}. Win_macOS/elevation')
                 self.log_tile_debug(tile["x"], tile["y"], tile_count, timings_tile.stop_and_return())
 
             tile_count += 1

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -113,9 +113,11 @@ def check_installation_of_programs_credentials_for_contour_lines():
                     \nPlease refer to the Quickstart Guide of wahooMapsCreator for instructions:\n- https://github.com/treee111/wahooMapsCreator/blob/develop/docs/QUICKSTART_ANACONDA.md#additional-programs-for-generating-contour-lines \
                     \nor create an issue:\n- https://github.com/treee111/wahooMapsCreator/issues"
 
-    if not is_program_installed("phyghtmap"):
+    # TODO: remove chapter wahooMapsCreator/docs/QUICKSTART_ANACONDA.md#additional-programs-for-generating-contour-lines
+    # when switching to pyhgtmap
+    if not is_program_installed("pyhgtmap"):
         sys.exit(
-            f"phyghtmap is not installed. {text_to_docu}")
+            f"pyhgtmap is not installed. {text_to_docu}")
 
     username, password = read_earthexplorer_credentials()
 


### PR DESCRIPTION
## This PR…

- switches to file-versioned and published (PyPi) python module `pyhgtmap`
- no manual (kind of difficult) installation of `phyghtmap` needed anymore
- closes #217

## Considerations and implementations

Till now, there is no support for Windows, see https://github.com/agrenott/pyhgtmap/issues/7

## ToDO
adjust documentation
fix version of `pyhgtmap` and think of other publish-related stuff for this PR

## How to test

1. create environment gdal-dev-pyh using env .yml file
2. switch to the environment
3. swith to this branch
4. Run wahooMapsCreator and include contour lines using `-con`
5. Check if the result is the same as using `phyghtmap`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
