### PR TITLE
RFC, Use asyncio for external programs, just prototype for now

### DIFF
--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -96,11 +96,11 @@ def run(run_level):
         # Split filtered country files to tiles
         asyncio.run(o_osm_maps.split_filtered_country_files_to_tiles())
 
-        exit(0)
 
         # Merge splitted tiles with land and sea
-        o_osm_maps.merge_splitted_tiles_with_land_and_sea(
-            o_input_data.process_border_countries, o_input_data.contour)
+        asyncio.run(o_osm_maps.merge_splitted_tiles_with_land_and_sea(o_input_data.process_border_countries, o_input_data.contour))
+
+        exit(0)
 
         # Creating .map files
         o_osm_maps.create_map_files(o_input_data.save_cruiser,

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -100,11 +100,8 @@ def run(run_level):
         # Merge splitted tiles with land and sea
         asyncio.run(o_osm_maps.merge_splitted_tiles_with_land_and_sea(o_input_data.process_border_countries, o_input_data.contour))
 
-        exit(0)
-
         # Creating .map files
-        o_osm_maps.create_map_files(o_input_data.save_cruiser,
-                                    o_input_data.tag_wahoo_xml)
+        asyncio.run(o_osm_maps.create_map_files(o_input_data.save_cruiser, o_input_data.tag_wahoo_xml))
 
         # Zip .map.lzma files
         o_osm_maps.make_and_zip_files('.map.lzma', o_input_data.zip_folder)

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -4,6 +4,7 @@ executable file to create up-to-date map-files for the Wahoo ELEMNT and Wahoo EL
 #!/usr/bin/python
 
 # import official python packages
+import asyncio
 import logging
 
 # import custom python packages
@@ -75,7 +76,7 @@ def run(run_level):
         o_osm_maps = OsmMaps(o_osm_data)
 
         # Filter tags from country osm.pbf files'
-        o_osm_maps.filter_tags_from_country_osm_pbf_files()
+        asyncio.run(o_osm_maps.filter_tags_from_country_osm_pbf_files())
 
         # Generate land
         o_osm_maps.generate_land()

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -78,17 +78,15 @@ def run(run_level):
         # Filter tags from country osm.pbf files'
         asyncio.run(o_osm_maps.filter_tags_from_country_osm_pbf_files())
         
-
         # Generate land
         asyncio.run(o_osm_maps.generate_land())
-
 
         # Generate sea
         o_osm_maps.generate_sea()
 
         # Generate elevation
         if o_input_data.contour:
-            o_osm_maps.generate_elevation(o_input_data.use_srtm1)
+            asyncio.run(o_osm_maps.generate_elevation(o_input_data.use_srtm1))
 
         # Split filtered country files to tiles
         asyncio.run(o_osm_maps.split_filtered_country_files_to_tiles())

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -76,10 +76,15 @@ def run(run_level):
         o_osm_maps = OsmMaps(o_osm_data)
 
         # Filter tags from country osm.pbf files'
+#        with asyncio.Runner(true) as runner:
+#            runner.run(o_osm_maps.filter_tags_from_country_osm_pbf_files())
         asyncio.run(o_osm_maps.filter_tags_from_country_osm_pbf_files())
+        
 
         # Generate land
-        o_osm_maps.generate_land()
+        asyncio.run(o_osm_maps.generate_land())
+#        o_osm_maps.generate_land()
+
 
         # Generate sea
         o_osm_maps.generate_sea()
@@ -89,7 +94,9 @@ def run(run_level):
             o_osm_maps.generate_elevation(o_input_data.use_srtm1)
 
         # Split filtered country files to tiles
-        o_osm_maps.split_filtered_country_files_to_tiles()
+        asyncio.run(o_osm_maps.split_filtered_country_files_to_tiles())
+
+        exit(0)
 
         # Merge splitted tiles with land and sea
         o_osm_maps.merge_splitted_tiles_with_land_and_sea(

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -76,14 +76,11 @@ def run(run_level):
         o_osm_maps = OsmMaps(o_osm_data)
 
         # Filter tags from country osm.pbf files'
-#        with asyncio.Runner(true) as runner:
-#            runner.run(o_osm_maps.filter_tags_from_country_osm_pbf_files())
         asyncio.run(o_osm_maps.filter_tags_from_country_osm_pbf_files())
         
 
         # Generate land
         asyncio.run(o_osm_maps.generate_land())
-#        o_osm_maps.generate_land()
 
 
         # Generate sea
@@ -95,7 +92,6 @@ def run(run_level):
 
         # Split filtered country files to tiles
         asyncio.run(o_osm_maps.split_filtered_country_files_to_tiles())
-
 
         # Merge splitted tiles with land and sea
         asyncio.run(o_osm_maps.merge_splitted_tiles_with_land_and_sea(o_input_data.process_border_countries, o_input_data.contour))

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -621,6 +621,9 @@ class OsmMaps:
         tile_count = 1
         for tile in self.o_osm_data.tiles:
             timings_tile = Timings()
+
+            out_file_map = os.path.join(USER_OUTPUT_DIR, f'{tile["x"]}', f'{tile["y"]}.map')
+
             # Create "tile present" file
             with open(out_file_map + '.lzma.17', mode='wb') as tile_present_file:
                 tile_present_file.close()

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -670,7 +670,7 @@ class OsmMaps:
 
             # --keep: do not delete source file
             if save_cruiser:
-                cmd.append('--keep')
+                args.append('--keep')
 
         await run_async_subprocess_and_log_output(semaphore, cmd, args, f'! Error creating map files for tile: {tile["x"]},{tile["y"]}')
 

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -571,7 +571,7 @@ class OsmMaps:
 
         await run_async_subprocess_and_log_output(semaphore, cmd, args, f'! Error in Osmosis with sorting land* osm files of tile: {tile["x"]},{tile["y"]}')
 
-    def create_map_files(self, save_cruiser, tag_wahoo_xml):
+    async def create_map_files(self, save_cruiser, tag_wahoo_xml):
         """
         Creating .map files
         """
@@ -580,64 +580,47 @@ class OsmMaps:
         log.info('# Creating .map files for tiles')
 
         # Number of threads to use in the mapwriter plug-in
-        threads = multiprocessing.cpu_count() - 1
-        if int(threads) < 1:
-            threads = 1
+#        threads = multiprocessing.cpu_count() - 1
+#        if int(threads) < 1:
+#            threads = 1
 
+        semaphore = asyncio.Semaphore(15)
+        tasks = set()
         timings = Timings()
         tile_count = 1
         for tile in self.o_osm_data.tiles:
-            self.log_tile_info(tile["x"], tile["y"], tile_count)
+#            self.log_tile_info(tile["x"], tile["y"], tile_count)
             timings_tile = Timings()
 
-            out_file_map = os.path.join(USER_OUTPUT_DIR,
-                                        f'{tile["x"]}', f'{tile["y"]}.map')
+            out_file_map = os.path.join(USER_OUTPUT_DIR, f'{tile["x"]}', f'{tile["y"]}.map')
 
             # apply tag-wahoo xml every time because the result is different per .xml file (user input)
-            merged_file = os.path.join(USER_OUTPUT_DIR,
-                                       f'{tile["x"]}', f'{tile["y"]}', 'merged.osm.pbf')
+            merged_file = os.path.join(USER_OUTPUT_DIR, f'{tile["x"]}', f'{tile["y"]}', 'merged.osm.pbf')
 
-            # Windows
-            if platform.system() == "Windows":
-                cmd = [OSMOSIS_WIN_FILE_PATH, '--rbf', merged_file,
-                       'workers=' + self.workers, '--mw', 'file='+out_file_map]
-            # Non-Windows
-            else:
-                cmd = ['osmosis', '--rb', merged_file,
-                       '--mw', 'file='+out_file_map]
+            tasks.add(asyncio.create_task(self.invoke_create_map_file_linux(semaphore, tile, tag_wahoo_xml, merged_file, out_file_map)))
+            tile_count += 1
 
-            cmd.append(
-                f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')
-            cmd.append('zoom-interval-conf=10,0,17')
-            cmd.append(f'threads={threads}')
-            # add path to tag-wahoo xml file
-            try:
-                cmd.append(
-                    f'tag-conf-file={get_tag_wahoo_xml_path(tag_wahoo_xml)}')
-            except TagWahooXmlNotFoundError:
-                log.error(
-                    'The tag-wahoo xml file was not found: ˚%s˚. Does the file exist and is your input correct?', tag_wahoo_xml)
-                sys.exit()
+        await asyncio.gather(*tasks)
 
-            run_subprocess_and_log_output(
-                cmd, f'Error in creating map file via Osmosis with tile: {tile["x"]},{tile["y"]}. mapwriter plugin installed?')
+        log.info('+ Created .map files for tiles: OK, %s', timings.stop_and_return())
 
-            # Windows
-            if platform.system() == "Windows":
-                cmd = [get_tooling_win_path('lzma'), 'e', out_file_map,
-                       out_file_map+'.lzma', f'-mt{threads}', '-d27', '-fb273', '-eos']
-            # Non-Windows
-            else:
-                # force overwrite of output file and (de)compress links
-                cmd = ['lzma', out_file_map, '-f']
+        semaphore = asyncio.Semaphore(30)
+        tasks = set()
+        tile_count = 1
+        for tile in self.o_osm_data.tiles:
+            timings_tile = Timings()
 
-                # --keep: do not delete source file
-                if save_cruiser:
-                    cmd.append('--keep')
+            out_file_map = os.path.join(USER_OUTPUT_DIR, f'{tile["x"]}', f'{tile["y"]}.map')
 
-            run_subprocess_and_log_output(
-                cmd, f'! Error creating map files for tile: {tile["x"]},{tile["y"]}')
+            tasks.add(asyncio.create_task(self.invoke_compress_map_file_linux(semaphore, tile, save_cruiser, out_file_map)))
 
+        await asyncio.gather(*tasks)
+
+        log.info('+ Compressed .map files for tiles: OK, %s', timings.stop_and_return())
+
+        tile_count = 1
+        for tile in self.o_osm_data.tiles:
+            timings_tile = Timings()
             # Create "tile present" file
             with open(out_file_map + '.lzma.17', mode='wb') as tile_present_file:
                 tile_present_file.close()
@@ -646,6 +629,45 @@ class OsmMaps:
             tile_count += 1
 
         log.info('+ Creating .map files for tiles: OK, %s', timings.stop_and_return())
+
+    async def invoke_create_map_file_linux(self, semaphore, tile, tag_wahoo_xml, merged_file, out_file_map):
+        # Windows
+        if platform.system() == "Windows":
+            cmd = OSMOSIS_WIN_FILE_PATH
+            args = ['--rbf', merged_file, 'workers=1', '--mw', 'file='+out_file_map]
+        # Non-Windows
+        else:
+            cmd = 'osmosis'
+            args = ['--rb', merged_file, '--mw', 'file='+out_file_map]
+
+        args.append(f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')
+        args.append('zoom-interval-conf=10,0,17')
+        args.append(f'threads=1')
+        # add path to tag-wahoo xml file
+        try:
+            args.append(f'tag-conf-file={get_tag_wahoo_xml_path(tag_wahoo_xml)}')
+        except TagWahooXmlNotFoundError:
+            log.error('The tag-wahoo xml file was not found: ˚%s˚. Does the file exist and is your input correct?', tag_wahoo_xml)
+            sys.exit()
+
+        await run_async_subprocess_and_log_output(semaphore, cmd, args, f'! Error in creating map file via Osmosis with tile: {tile["x"]},{tile["y"]}. mapwriter plugin installed?')
+
+    async def invoke_compress_map_file_linux(self, semaphore, tile, save_cruiser, out_file_map):
+        # Windows
+        if platform.system() == "Windows":
+            cmd = get_tooling_win_path('lzma')
+            args = ['e', out_file_map, out_file_map+'.lzma', f'-mt1', '-d27', '-fb273', '-eos']
+        # Non-Windows
+        else:
+            # force overwrite of output file and (de)compress links
+            cmd = 'lzma'
+            args = [out_file_map, '-f']
+
+            # --keep: do not delete source file
+            if save_cruiser:
+                cmd.append('--keep')
+
+        await run_async_subprocess_and_log_output(semaphore, cmd, args, f'! Error creating map files for tile: {tile["x"]},{tile["y"]}')
 
     def make_and_zip_files(self, extension, zip_folder):
         """

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -172,27 +172,13 @@ class OsmMaps:
                         or self.last_changed_is_identical_to_last_run(key) is False:
                     log.info(
                         '+ Filtering unwanted map objects out of map of %s', key)
+                        
+                    tags_to_keep = translate_tags_to_keep(sys_platform=platform.system())
+                    self.invoke_filter_tags_osmium_linux(key, val['map_file'], tags_to_keep, out_file_pbf_filtered_mac)
 
-                    # https://docs.osmcode.org/osmium/latest/osmium-tags-filter.html
-                    cmd = ['osmium', 'tags-filter', '--remove-tags']
-                    cmd.append(val['map_file'])
-                    cmd.extend(translate_tags_to_keep(
-                        sys_platform=platform.system()))
-                    cmd.extend(['-o', out_file_pbf_filtered_mac])
-                    cmd.append('--overwrite')
+                    tags_to_keep = translate_tags_to_keep(name_tags=True, sys_platform=platform.system())
+                    self.invoke_filter_tags_osmium_linux(key, val['map_file'], tags_to_keep, out_file_pbf_filtered_names_mac)
 
-                    run_subprocess_and_log_output(
-                        cmd, f'! Error in Osmium with country: {key}')
-
-                    cmd = ['osmium', 'tags-filter', '--remove-tags']
-                    cmd.append(val['map_file'])
-                    cmd.extend(translate_tags_to_keep(
-                        name_tags=True, sys_platform=platform.system()))
-                    cmd.extend(['-o', out_file_pbf_filtered_names_mac])
-                    cmd.append('--overwrite')
-
-                    run_subprocess_and_log_output(
-                        cmd, f'! Error in Osmium with country: {key}')
 
                 val['filtered_file'] = out_file_pbf_filtered_mac
                 val['filtered_file_names'] = out_file_pbf_filtered_names_mac
@@ -201,6 +187,16 @@ class OsmMaps:
             self.write_country_config_file(key)
 
         log.info('+ Filter tags from country osm.pbf files: OK, %s', timings.stop_and_return())
+
+    def invoke_filter_tags_osmium_linux(self, country, map_file, tags_to_keep, out_filename):
+        # https://docs.osmcode.org/osmium/latest/osmium-tags-filter.html
+        cmd = ['osmium', 'tags-filter', '--remove-tags']
+        cmd.append(map_file)
+        cmd.extend(tags_to_keep)
+        cmd.extend(['-o', out_filename])
+        cmd.append('--overwrite')
+
+        run_subprocess_and_log_output(cmd, f'! Error in Osmium with country: {country}')
 
     def generate_land(self):
         """

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -584,7 +584,7 @@ class OsmMaps:
 #        if int(threads) < 1:
 #            threads = 1
 
-        semaphore = asyncio.Semaphore(15)
+        semaphore = asyncio.Semaphore(12)
         tasks = set()
         timings = Timings()
         tile_count = 1

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -319,7 +319,7 @@ class OsmMaps:
 
         log.info('+ Generate sea for each coordinate: OK, %s', timings.stop_and_return())
 
-    def generate_elevation(self, use_srtm1):
+    async def generate_elevation(self, use_srtm1):
         """
         Generate contour lines for all tiles
         """
@@ -330,6 +330,7 @@ class OsmMaps:
 
         hgt_path = os.path.join(USER_DL_DIR, 'hgt')
 
+        semaphore = asyncio.Semaphore(28)
         tasks = set()
         timings = Timings()
         tile_count = 1
@@ -350,34 +351,35 @@ class OsmMaps:
                 # 2) set source
                 elevation_source = '--source=srtm1,view1,view3,srtm3'
             else:
-                # 1) search vor view1 elevation files
+                # 1) search for view1 elevation files
                 out_file_elevation_existing = glob.glob(os.path.join(
                     USER_OUTPUT_DIR, str(tile["x"]), str(tile["y"]), 'elevation*view1*.osm'))
                 # 2) set source
-                elevation_source = '--source=view1,view3,srtm3'
+                elevation_source = '--source=view1,view3'
 
             # check for already existing elevation .osm file (the ones matched via glob)
             if not (len(out_file_elevation_existing) == 1 and os.path.isfile(out_file_elevation_existing[0])) \
                     or self.o_osm_data.force_processing is True:
-                self.log_tile_info(tile["x"], tile["y"], tile_count)
-                timings_tile = Timings()
-                cmd = ['phyghtmap']
-                cmd.append('-a ' + f'{tile["left"]}' + ':' + f'{tile["bottom"]}' +
-                           ':' + f'{tile["right"]}' + ':' + f'{tile["top"]}')
-                cmd.extend(['-o', f'{out_file_elevation}', '-s 10', '-c 100,50', elevation_source,
-                            '--jobs=8', '--viewfinder-mask=1', '--start-node-id=20000000000',
-                            '--max-nodes-per-tile=0', '--start-way-id=2000000000', '--write-timestamp',
-                            '--no-zero-contour', '--hgtdir=' + hgt_path])
-                cmd.append('--earthexplorer-user=' + username)
-                cmd.append('--earthexplorer-password=' + password)
-
-                run_subprocess_and_log_output(
-                    cmd, f'! Error in phyghtmap with tile: {tile["x"]},{tile["y"]}. Win_macOS/elevation')
-                self.log_tile_debug(tile["x"], tile["y"], tile_count, timings_tile.stop_and_return())
+#                self.log_tile_info(tile["x"], tile["y"], tile_count)
+                tasks.add(asyncio.create_task(self.invoke_generate_elevation_for_tile(semaphore, tile, elevation_source, hgt_path, username, password, out_file_elevation)))
 
             tile_count += 1
 
+        await asyncio.gather(*tasks)
+
         log.info('+ Generate contour lines for each coordinate: OK, %s', timings.stop_and_return())
+
+    async def invoke_generate_elevation_for_tile(self, semaphore, tile, elevation_source, hgt_path, username, password, out_file_elevation):
+        cmd = 'pyhgtmap'
+        args = ['-a ' + f'{tile["left"]}' + ':' + f'{tile["bottom"]}' + ':' + f'{tile["right"]}' + ':' + f'{tile["top"]}']
+        args.extend(['-o', f'{out_file_elevation}', '-s 10', '-c 100,50', elevation_source,
+                            '--jobs=1', '--viewfinder-mask=1', '--start-node-id=20000000000',
+                            '--max-nodes-per-tile=0', '--start-way-id=2000000000', '--write-timestamp',
+                            '--no-zero-contour', '--hgtdir=' + hgt_path])
+        args.append('--earthexplorer-user=' + username)
+        args.append('--earthexplorer-password=' + password)
+
+        await run_async_subprocess_and_log_output(semaphore, cmd, args, f'! Error in phyghtmap with tile: {tile["x"]},{tile["y"]}')
 
     async def split_filtered_country_files_to_tiles(self):
         """

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -386,7 +386,7 @@ class OsmMaps:
 
         log.info('-' * 80)
         log.info('# Split filtered country files to tiles')
-        semaphore = asyncio.Semaphore(20)
+        semaphore = asyncio.Semaphore(6)
         tasks = set()
         timings = Timings()
         tile_count = 1

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -134,9 +134,9 @@ def check_installation_of_programs_credentials_for_contour_lines():
                     \nPlease refer to the Quickstart Guide of wahooMapsCreator for instructions:\n- https://github.com/treee111/wahooMapsCreator/blob/develop/docs/QUICKSTART_ANACONDA.md#additional-programs-for-generating-contour-lines \
                     \nor create an issue:\n- https://github.com/treee111/wahooMapsCreator/issues"
 
-    if not is_program_installed("phyghtmap"):
+    if not is_program_installed("pyhgtmap"):
         sys.exit(
-            f"phyghtmap is not installed. {text_to_docu}")
+            f"pyhgtmap is not installed. {text_to_docu}")
 
     username, password = read_earthexplorer_credentials()
 


### PR DESCRIPTION
## This PR…

Use Python asyncio library to launch external programs in parallell where possible, to speed up the generation on multi CPU core machines.

## Considerations and implementations

This is just a proof of concept as of now, with several hacks, and also not considering Windows to any extent as of now.

So mainly to get some early feedback if possible, on the general approach.

I will add a method to calculate the number of Semaphores, based on "max CPU core used by external program invocation, min memory required by each external program invocation".

Will probably also take parts of this pull request, and make a general "reduce code duplication", and have that PR be merged first.

Also unsure if I should have one method for linux and one for windows for setting up the parameters for each external program invocation case, or one method with if tests for linux and windows. Currently, I have a mix of these, and I think one place I just removed the windows part when I was hacking the very first attempts, will readd the Windows support there in this PR.

I have also commented out the logging for each tile, since unsure how much sense that makes now. Will think about it, it would be useful if something is hanging or causing error.

Also note that is really pays of to have the
_tiles/germany/ directory, which contains the two files
```
filtered_names.o5m.pbf
filtered.o5m.pbf
```
put on a RAM disk (dev/shm for example). So I think a PR to add some config options somehow to control where those two files are put, would be really useful. If they are on disk or SSD, you will get a lot of iowait in the filtering step, since each tile is reading those files then.

I see a 10 fold increase in performance on some steps when looking at Norway, when running on a 16 core CPU (32 threads),  64 GB RAM.

Here is the output for Germany on my machine with asyncio
```
INFO:# Filter tags from country osm.pbf files
INFO:+ Filtering unwanted map objects out of map of germany
INFO:+ Filter tags from country osm.pbf files: OK, took 99.655 s
INFO:--------------------------------------------------------------------------------
INFO:# Generate land for each coordinate
INFO:start land sea
INFO:start land1
INFO:+ Generate land for each coordinate: OK, took 6.896 s
INFO:--------------------------------------------------------------------------------
INFO:# Generate sea for each coordinate
INFO:+ Generate sea for each coordinate: OK, took 0.004 s
INFO:--------------------------------------------------------------------------------
INFO:# Split filtered country files to tiles
INFO:+ Split filtered country files to tiles: OK, took 214.493 s
INFO:--------------------------------------------------------------------------------
INFO:# Merge splitted tiles with land, elevation, and sea
INFO:+ Sorted: OK, took 2.835 s
INFO:+ Merge splitted tiles with land, elevation, and sea: OK, took 36.320 s
INFO:--------------------------------------------------------------------------------
INFO:# Creating .map files for tiles
INFO:+ Created .map files for tiles: OK, took 107.150 s
INFO:+ Compressed .map files for tiles: OK, took 122.797 s (this is time from start, so compress took 15 s)
INFO:+ Creating .map files for tiles: OK, took 122.799 s
INFO:--------------------------------------------------------------------------------
INFO:# Create: .map.lzma files
INFO:+ Country: germany
INFO:+ Copying .map.lzma tiles to output folders
INFO:+ Create .map.lzma files: OK, took 1.189 s
INFO:--------------------------------------------------------------------------------
INFO:# Total time 481.898 s
```

Here is when running the upstream develop code, not using asyncio (just showing the main parts of the log)
```
INFO:+ Filter tags from country osm.pbf files: OK, took 121.303 s
INFO:+ Generate land for each coordinate: OK, took 19.885 s
INFO:+ Generate sea for each coordinate: OK, took 0.005 s
INFO:+ Split filtered country files to tiles: OK, took 562.958 s
INFO:+ Merge splitted tiles with land, elevation, and sea: OK, took 219.167 s
INFO:+ Creating .map files for tiles: OK, took 551.492 s
INFO:+ Create .map.lzma files: OK, took 1.094 s
INFO:# Total time 1476.415 s
```

So a 3x increase in performance for Germany.


{...}

## How to test

Invoke as normal, but as of now manually adjust the Semphore settings, which control how many parallel external programs are running.

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [ ] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
