### PR TITLE
[DEV] Update dependencies osmosis and mapwriter plugin incl. documenation

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -3,6 +3,7 @@
 - [Usage of wahooMapsCreator](#usage-of-wahoomapscreator)
   - [The tool stops but does not output an error](#the-tool-stops-but-does-not-output-an-error)
   - [I have a Java error. "Java heap space - out of memory"](#i-have-a-java-error-java-heap-space---out-of-memory)
+  - [I have a Osmosis error. "Task type mw doesn't exist"](#i-have-a-osmosis-error-task-type-mw-doesnt-exist)
   - [How can I migrate from v3.x.x to v4.x.x?](#how-can-i-migrate-from-v3xx-to-v4xx)
 - [Generated maps](#generated-maps)
   - [Where on my Wahoo device do I have to copy the maps?](#where-on-my-wahoo-device-do-i-have-to-copy-the-maps)
@@ -33,6 +34,24 @@ There are some possible workarounds:
 set JAVACMD_OPTIONS=-server -Xmx3G
 ```
 3. A permanent workaround (in opposite to 2.) is making changes from this PR https://github.com/treee111/wahooMapsCreator/pull/171/files in the osmosis.bat file on your computer. This file located here: `wahooMapsCreatorData\_download\tooling_win\Osmosis\bin\osmosis.bat`.
+
+### I have a Osmosis error. "Task type mw doesn't exist" 
+You might have osmosis installed in version 0.49.0 or 0.49.1 and might be using macOS or Linux. If yes, this error occurs during creation of the .map files: 
+```
+org.openstreetmap.osmosis.core.OsmosisRuntimeException: Task type mw doesn't exist.
+```
+
+In these two versions 0.49.0 and 0.49.1, the feature we use for loading the mapwriter plugin was removed and just brought back in version 0.49.2.
+
+You can list your version of osmosis on macOS/Linux with:
+```
+brew list osmosis
+```
+
+You can upgrade osmosis on macOS/Linux with:
+```
+brew upgrade osmosis
+```
 
 ### How can I migrate from v3.x.x to v4.x.x?
 You have to remove your existing environment:

--- a/docs/QUICKSTART_ANACONDA.md
+++ b/docs/QUICKSTART_ANACONDA.md
@@ -70,7 +70,7 @@ https://brew.sh/
 ```
 brew install osmium-tool
 ```
-2. Download **Osmosis** latest version from Github
+2. Install **Osmosis** using homebrew in terminal:
 ```
 brew install osmosis
 ```

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -185,7 +185,7 @@ class TestDownloader(unittest.TestCase):
         """
         if platform.system() != "Windows":
             path = os.path.join(str(constants.USER_DIR), '.openstreetmap', 'osmosis',
-                                'plugins', 'mapsforge-map-writer-0.18.0-jar-with-dependencies.jar')
+                                'plugins', 'mapsforge-map-writer-0.20.0-jar-with-dependencies.jar')
 
             if os.path.exists(path):
                 os.remove(path)
@@ -195,6 +195,19 @@ class TestDownloader(unittest.TestCase):
             download_tooling()
 
             self.assertTrue(os.path.exists(path))
+
+    def test_map_writer_url_calculation(self):
+        """
+        Test if joining mapwriter filename to base path is the same as the full path
+        """
+        map_writer_filename = 'mapsforge-map-writer-0.18.0-jar-with-dependencies.jar'
+        mapwriter_plugin_url = 'https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.18.0/mapsforge-map-writer-0.18.0-jar-with-dependencies.jar'
+
+        mapwriter_plugin_url_base = 'https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.18.0'
+        mapwriter_plugin_url_join = os.path.join(mapwriter_plugin_url_base, map_writer_filename)
+
+        self.assertEqual(mapwriter_plugin_url_join, mapwriter_plugin_url)
+
 
     def check_exp_agains_composed_map_file_path(self, country, country_map_file_path):
         """

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -106,15 +106,16 @@ def download_url_to_file(url, map_file_path):
 def download_tooling():
     """
     Windows
-    - check for Windows tooling
+    - check for Windows tooling (osmosis, osmfilter)
     - download if Windows tooling is not available
     --> this is done to bring down the filesize of the python module
+    - check for mapwriter plugin and download if not existing
 
     macOS
     - check for mapwriter plugin and download if not existing
     """
-
-    mapwriter_plugin_url = 'https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.18.0/mapsforge-map-writer-0.18.0-jar-with-dependencies.jar'
+    map_writer_filename = 'mapsforge-map-writer-0.20.0-jar-with-dependencies.jar'
+    mapwriter_plugin_url = os.path.join('https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.20.0', map_writer_filename)
 
     # Windows
     if platform.system() == "Windows":
@@ -133,12 +134,12 @@ def download_tooling():
                           'http://m.m.i24.cc/osmfilter.exe')
 
         mapwriter_plugin_path = os.path.join(USER_TOOLING_WIN_DIR,
-                                             'Osmosis', 'lib', 'default', 'mapsforge-map-writer-0.18.0-jar-with-dependencies.jar')
+                                             'Osmosis', 'lib', 'default', map_writer_filename)
 
     # Non-Windows
     else:
         mapwriter_plugin_path = os.path.join(
-            str(USER_DIR), '.openstreetmap', 'osmosis', 'plugins', 'mapsforge-map-writer-0.18.0-jar-with-dependencies.jar')
+            str(USER_DIR), '.openstreetmap', 'osmosis', 'plugins', map_writer_filename)
 
     if not os.path.isfile(mapwriter_plugin_path):
         log.info('# Need to download Osmosis mapwriter plugin')

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -124,7 +124,7 @@ def download_tooling():
         if not os.path.isfile(OSMOSIS_WIN_FILE_PATH):
             log.info('# Need to download Osmosis application for Windows')
             download_file(OSMOSIS_WIN_FILE_PATH,
-                          'https://github.com/openstreetmap/osmosis/releases/download/0.48.3/osmosis-0.48.3.zip',
+                          'https://github.com/openstreetmap/osmosis/releases/download/0.49.2/osmosis-0.49.2.zip',
                           get_tooling_win_path('Osmosis', in_user_dir=True))
 
         if not os.path.isfile(get_tooling_win_path('osmfilter.exe', in_user_dir=True)):


### PR DESCRIPTION
## This PR…

- osmosis did remove JPF java plugin framework which we use for loading the mapwriter plugin

- closes #229 

## Considerations and implementations

JPF was brought back to osmosis in version 0.49.2
- via https://github.com/openstreetmap/osmosis/pull/141
- issue was reported via https://github.com/openstreetmap/osmosis/pull/140
- publish to brew with https://github.com/Homebrew/homebrew-core/pull/156228 

## How to test

1. use wahoomc as usual

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
