### PR TITLE
[FIX] Fix invalid color for bolt2-track-raw-cycle ways in VTM theme

### DIFF
--- a/device_themes/vtm_theme_poi/vtm-elemnt.xml
+++ b/device_themes/vtm_theme_poi/vtm-elemnt.xml
@@ -82,7 +82,7 @@
 
    <style-line id="roam-track-raw-cycle" use="roam-track-raw" stroke="#0000FF" />
    <style-line id="bolt-track-raw-cycle" use="bolt-track-raw" />
-   <style-line id="bolt2-track-raw-cycle" cat="bolt2" stroke="#CCCCCC" dasharray="6,3"/>
+   <style-line id="bolt2-track-raw-cycle" cat="bolt2" stroke="#000000" dasharray="6,3"/>
    <style-line id="bolt2-track-raw-cycle-dark" use="bolt2-track-raw-dark" stroke="#00AAFF" />
 
    <!-- Tracks that don't have other info -->


### PR DESCRIPTION
## This PR...

Fixes #221 by using a valid color for `bolt2-track-raw-cycle`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
