### PR TITLE
[FIX] Return error code of failed subprocess instead of success (which is the default)

### DIFF
--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -53,7 +53,7 @@ def run_subprocess_and_log_output(cmd, error_message, cwd=""):
             log.error(process.stderr)
 
         log.error(error_message)
-        sys.exit()
+        sys.exit(process.returncode)
 
     elif process.stdout:
         log.debug('subprocess debug output:')


### PR DESCRIPTION
Although a subprocess fails during map creation, the return code of the wahoomc process is 0, i.e. good. This PR returns the code of the subprocess in case of an error so it's possible to determine if the map creation really succeeded.