### PR TITLE
[DEV] update dependency mapwriter plugin from 0.20.0 to 0.21.0

### DIFF
--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -113,9 +113,11 @@ def download_tooling():
 
     macOS
     - check for mapwriter plugin and download if not existing
+
+    check here for new mapwriter plugin version: https://github.com/mapsforge/mapsforge
     """
-    map_writer_filename = 'mapsforge-map-writer-0.20.0-jar-with-dependencies.jar'
-    mapwriter_plugin_url = os.path.join('https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.20.0', map_writer_filename)
+    map_writer_filename = 'mapsforge-map-writer-0.21.0-jar-with-dependencies.jar'
+    mapwriter_plugin_url = os.path.join('https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.21.0', map_writer_filename)
 
     # Windows
     if platform.system() == "Windows":


### PR DESCRIPTION
## This PR…

- update mapwriter plugin to latest version
- followup of https://github.com/treee111/wahooMapsCreator/pull/236

## Considerations and implementations
repo to check the latest version of mapwriter plugin: https://github.com/mapsforge/mapsforge
documentation for mapwriter plugin: https://github.com/mapsforge/mapsforge/blob/master/docs/Getting-Started-Map-Writer.md

## How to test

1. run wahooMapsCreator as usuall with `-fp` to force processing/generation of maps

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
