### PR TITLE
[FIX] Windows: Downgrade Osmosis to v0.48.3 and cleanup user directory `tooling_win/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-A list of unreleased changes can be found [here](https://github.com/treee111/wahooMapsCreator/compare/v4.2.0...HEAD).
+A list of unreleased changes can be found [here](https://github.com/treee111/wahooMapsCreator/compare/v4.2.1a0...HEAD).
+
+<a name="4.2.1a0"></a>
+## [4.2.1a0] - 2024-10-14
+### Features
+- remove coding handling breaking changes and unused function ([#256](https://github.com/treee111/wahooMapsCreator/issues/256)) [`43e07b4`](https://github.com/treee111/wahooMapsCreator/commit/43e07b4ffb0517eed5d53b9177c0d7dd76b8e8a3)
+
+### Bug Fixes
+- make mapwriter download URL OS independent [`e5d19bd`](https://github.com/treee111/wahooMapsCreator/commit/e5d19bdc52c322910635dfb55bb6a19040cc3e63)
+- **Windows:** Revert Windows part of "[DEV] Update dependencies osmosis and mapwriter plugin incl. documenation ([#236](https://github.com/treee111/wahooMapsCreator/issues/236))" [`dcd3a57`](https://github.com/treee111/wahooMapsCreator/commit/dcd3a573934f0d5dc3033dee6cc385f5902bd000)
+
+### Development/Infrastructure/Test/CI
+- Create LICENSE file ([#257](https://github.com/treee111/wahooMapsCreator/issues/257)) [`827f464`](https://github.com/treee111/wahooMapsCreator/commit/827f464c60652d2f3c11f47236703a9cea4f44ee)
+
 
 <a name="4.2.0"></a>
 ## [4.2.0] - 2024-09-12
@@ -473,6 +486,7 @@ wahooMapsCreator can now be used much quicker and easier!
     - Windows:    `tooling_windows/Windows-Wahoo-Map-Creator-Osmosis/wahoo-map-creator-osmosis.py`
 
 
+[4.2.1a0]: https://github.com/treee111/wahooMapsCreator/compare/v4.2.0...v4.2.1a0
 [4.2.0]: https://github.com/treee111/wahooMapsCreator/compare/v4.1.1...v4.2.0
 [4.1.1]: https://github.com/treee111/wahooMapsCreator/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/treee111/wahooMapsCreator/compare/v4.0.2...v4.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-A list of unreleased changes can be found [here](https://github.com/treee111/wahooMapsCreator/compare/v4.2.1a0...HEAD).
+A list of unreleased changes can be found [here](https://github.com/treee111/wahooMapsCreator/compare/v4.2.1a1...HEAD).
 
-<a name="4.2.1a0"></a>
-## [4.2.1a0] - 2024-10-14
+<a name="4.2.1a1"></a>
+## [4.2.1a1] - 2024-10-14
 ### Features
 - remove coding handling breaking changes and unused function ([#256](https://github.com/treee111/wahooMapsCreator/issues/256)) [`43e07b4`](https://github.com/treee111/wahooMapsCreator/commit/43e07b4ffb0517eed5d53b9177c0d7dd76b8e8a3)
 
@@ -486,7 +486,7 @@ wahooMapsCreator can now be used much quicker and easier!
     - Windows:    `tooling_windows/Windows-Wahoo-Map-Creator-Osmosis/wahoo-map-creator-osmosis.py`
 
 
-[4.2.1a0]: https://github.com/treee111/wahooMapsCreator/compare/v4.2.0...v4.2.1a0
+[4.2.1a1]: https://github.com/treee111/wahooMapsCreator/compare/v4.2.0...v4.2.1a1
 [4.2.0]: https://github.com/treee111/wahooMapsCreator/compare/v4.1.1...v4.2.0
 [4.1.1]: https://github.com/treee111/wahooMapsCreator/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/treee111/wahooMapsCreator/compare/v4.0.2...v4.1.0

--- a/conda_env/gdal-user.yml
+++ b/conda_env/gdal-user.yml
@@ -10,4 +10,4 @@ dependencies:
   - matplotlib=3.4.3
   - pip
   - pip:
-      - wahoomc==4.2.1a0
+      - wahoomc==4.2.1a1

--- a/conda_env/gdal-user.yml
+++ b/conda_env/gdal-user.yml
@@ -10,4 +10,4 @@ dependencies:
   - matplotlib=3.4.3
   - pip
   - pip:
-      - wahoomc==4.2.0
+      - wahoomc==4.2.1a0

--- a/conda_env/gdal-user.yml
+++ b/conda_env/gdal-user.yml
@@ -10,4 +10,4 @@ dependencies:
   - matplotlib=3.4.3
   - pip
   - pip:
-      - wahoomc==4.2.1a1
+      - wahoomc==4.2.1a4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 4.2.0
+version = 4.2.1a0
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 4.2.1a0
+version = 4.2.1a1
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wahoomc
-version = 4.2.1a1
+version = 4.2.1a4
 author = Benjamin Kreuscher
 author_email = benni.kreuscher@gmail.com
 description = Create maps for your Wahoo bike computer based on latest OSM maps 

--- a/wahoomc/constants.py
+++ b/wahoomc/constants.py
@@ -26,7 +26,7 @@ RESOURCES_DIR = os.path.join(WAHOO_MC_DIR, 'resources')
 TOOLING_WIN_DIR = os.path.join(WAHOO_MC_DIR, 'tooling_win')
 # location of repo / python installation - not used
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-VERSION = '4.2.1a1'
+VERSION = '4.2.1a4'
 
 
 block_download = ['dach', 'alps', 'britain-and-ireland', 'south-africa-and-lesotho',

--- a/wahoomc/constants.py
+++ b/wahoomc/constants.py
@@ -26,7 +26,7 @@ RESOURCES_DIR = os.path.join(WAHOO_MC_DIR, 'resources')
 TOOLING_WIN_DIR = os.path.join(WAHOO_MC_DIR, 'tooling_win')
 # location of repo / python installation - not used
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-VERSION = '4.2.1a0'
+VERSION = '4.2.1a1'
 
 
 block_download = ['dach', 'alps', 'britain-and-ireland', 'south-africa-and-lesotho',

--- a/wahoomc/constants.py
+++ b/wahoomc/constants.py
@@ -26,7 +26,7 @@ RESOURCES_DIR = os.path.join(WAHOO_MC_DIR, 'resources')
 TOOLING_WIN_DIR = os.path.join(WAHOO_MC_DIR, 'tooling_win')
 # location of repo / python installation - not used
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-VERSION = '4.2.0'
+VERSION = '4.2.1a0'
 
 
 block_download = ['dach', 'alps', 'britain-and-ireland', 'south-africa-and-lesotho',

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -126,7 +126,7 @@ def download_tooling():
         if not os.path.isfile(OSMOSIS_WIN_FILE_PATH):
             log.info('# Need to download Osmosis application for Windows')
             download_file(OSMOSIS_WIN_FILE_PATH,
-                          'https://github.com/openstreetmap/osmosis/releases/download/0.49.2/osmosis-0.49.2.zip',
+                          'https://github.com/openstreetmap/osmosis/releases/download/0.48.3/osmosis-0.48.3.zip',
                           get_tooling_win_path('Osmosis', in_user_dir=True))
 
         if not os.path.isfile(get_tooling_win_path('osmfilter.exe', in_user_dir=True)):

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -131,6 +131,19 @@ def delete_o5m_pbf_files_in_folder(folder):
                 pass
 
 
+def delete_all_files_in_folder(folder):
+    """
+    delete all files ald directories of given folder
+    """
+    files_and_folders = list(os.listdir(folder)) # [f for f in os.listdir(folder)]
+
+    for file in files_and_folders:
+        try:
+            os.remove(os.path.join(folder, file))
+        except OSError:
+            pass
+
+
 def copy_or_move_files_and_folder(from_path, to_path, delete_from_dir=False):
     """
     copy content from source directory to destination directory

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -131,7 +131,7 @@ def delete_o5m_pbf_files_in_folder(folder):
                 pass
 
 
-def delete_all_files_in_folder(folder):
+def delete_everything_in_folder(folder):
     """
     delete all files ald directories of given folder
     """
@@ -139,7 +139,14 @@ def delete_all_files_in_folder(folder):
 
     for file in files_and_folders:
         try:
-            os.remove(os.path.join(folder, file))
+            file_or_dir = os.path.join(folder, file)
+            # file or dir?
+            if os.path.isfile(file_or_dir):
+                # delete file
+                os.remove(file_or_dir)
+            else:
+                # delete directory if exists. copytree fails if dir exists already
+                shutil.rmtree(file_or_dir)
         except OSError:
             pass
 

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -13,12 +13,12 @@ import sys
 import pkg_resources
 
 # import custom python packages
-from wahoomc.file_directory_functions import write_json_file_generic, \
+from wahoomc.file_directory_functions import delete_all_files_in_folder, write_json_file_generic, \
     read_json_file_generic, copy_or_move_files_and_folder
 from wahoomc.constants_functions import get_tooling_win_path, get_absolute_dir_user_or_repo
 from wahoomc.downloader import get_latest_pypi_version
 
-from wahoomc.constants import GEOFABRIK_PATH, USER_WAHOO_MC
+from wahoomc.constants import GEOFABRIK_PATH, USER_TOOLING_WIN_DIR, USER_WAHOO_MC
 from wahoomc.constants import USER_DL_DIR
 from wahoomc.constants import USER_MAPS_DIR
 from wahoomc.constants import USER_OUTPUT_DIR
@@ -46,6 +46,19 @@ def adjustments_due_to_breaking_changes():
     handle breaking changes
     """
     version_last_run = read_version_last_run() # pylint: disable=unused-variable
+
+    # Osmosis in v.0.49.2 seams not to be working on WINDOWS since now
+    # - due to the path into it was downloaded, 'tooling_win/Osmosis/osmosis-0.49.2'
+    #                                   and not 'tooling_win/Osmosis'
+    # - due to behaviour of reading/using plugins in v0.49.2 that seams not to be compatible
+    #   of using any plugins and in particular the mapwriter plugin
+    # due to that all Windows tooling files deleted here.
+    if (version_last_run is None or \
+            pkg_resources.parse_version(VERSION) <= pkg_resources.parse_version('4.2.1')) and \
+            platform.system() == "Windows":
+        log.info(
+            'Last run was with version %s, deleting Windows Tooling files of %s directory due to possible bad files.', version_last_run, USER_TOOLING_WIN_DIR)
+        delete_all_files_in_folder(USER_TOOLING_WIN_DIR)
 
 
 def check_installation_of_required_programs():

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -13,7 +13,7 @@ import sys
 import pkg_resources
 
 # import custom python packages
-from wahoomc.file_directory_functions import delete_all_files_in_folder, write_json_file_generic, \
+from wahoomc.file_directory_functions import delete_everything_in_folder, write_json_file_generic, \
     read_json_file_generic, copy_or_move_files_and_folder
 from wahoomc.constants_functions import get_tooling_win_path, get_absolute_dir_user_or_repo
 from wahoomc.downloader import get_latest_pypi_version
@@ -58,7 +58,7 @@ def adjustments_due_to_breaking_changes():
             platform.system() == "Windows":
         log.info(
             'Last run was with version %s, deleting Windows Tooling files of %s directory due to possible bad files.', version_last_run, USER_TOOLING_WIN_DIR)
-        delete_all_files_in_folder(USER_TOOLING_WIN_DIR)
+        delete_everything_in_folder(USER_TOOLING_WIN_DIR)
 
 
 def check_installation_of_required_programs():


### PR DESCRIPTION
## This PR…

- closes #258
- Builds the download URL for mapwriter plugin OS independent
- Downgrades Osmosis on Windows to v0.48.3.
- deletes tooling_win directory before

## Considerations and implementations

Osmosis v0.49.2 on Windows might not been working at all since upgrading, due to
- the download into a subdir of Osmosis 
- but more due to not beeing able to use mapwriter plugin (at least in my installation)

## How to test

1. Checkout branch or alpha version `4.2.1a01`
2. Use wahooMapsCreator as usuall

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [x] Tested with Windows
