### PR TITLE
[FIX] Windows: Download Osmosis into in `Osmosis` and not into subfolder, example `Osmosis/osmosis-0.49.2`

### DIFF
--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -61,7 +61,10 @@ def download_file(target_filepath, url, target_dir=""):
             target_path = USER_DL_DIR
 
         # unpack it
-        unzip(dl_file_path, target_path)
+        if os.path.basename(target_dir) == 'Osmosis':
+            unzip_ignore_first_dir(dl_file_path, target_path)
+        else:
+            unzip(dl_file_path, target_path)
 
         os.remove(dl_file_path)
     else:
@@ -192,6 +195,27 @@ def unzip(source_filename, dest_dir):
     """
     with zipfile.ZipFile(source_filename, 'r') as zip_ref:
         zip_ref.extractall(dest_dir)
+
+
+def unzip_ignore_first_dir(source_filename, dest_dir):
+    """
+    unzip the given file into the given directory without the first directory.
+    made because of Osmosis was unzipped to Osmosis/osmosis-0.49.2
+    """
+    first_dir_processed = False
+    with zipfile.ZipFile(source_filename) as zip_file:
+        for zip_info in zip_file.infolist():
+            if zip_info.is_dir() and not first_dir_processed:
+                # ignore first dir in zip. for osmosis, this is 'osmosis-0.49.2' as of 14.10.2024
+                first_dir_processed = True
+                continue
+
+            # cut out first part of the dir. for osmosis, this is 'osmosis-0.49.2' as of 14.10.2024
+            dir_without_first_part = zip_info.filename.split('/', 1)[1]
+
+            # set name where to save to the newly created dir name
+            zip_info.filename = dir_without_first_part
+            zip_file.extract(zip_info, dest_dir)
 
 
 class Downloader:

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -133,7 +133,7 @@ def delete_o5m_pbf_files_in_folder(folder):
 
 def delete_everything_in_folder(folder):
     """
-    delete all files ald directories of given folder
+    delete all files and directories of given folder
     """
     files_and_folders = list(os.listdir(folder)) # [f for f in os.listdir(folder)]
 

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -131,6 +131,19 @@ def delete_o5m_pbf_files_in_folder(folder):
                 pass
 
 
+def delete_all_files_in_folder(folder):
+    """
+    delete all files ald directories of given folder
+    """
+    files_and_folders = list(os.listdir(folder)) # [f for f in os.listdir(folder)]
+
+    for file in files_and_folders:
+        try:
+            os.remove(os.path.join(folder, file))
+        except OSError:
+            pass
+
+
 def copy_or_move_files_and_folder(from_path, to_path, delete_from_dir=False):
     """
     copy content from source directory to destination directory

--- a/wahoomc/file_directory_functions.py
+++ b/wahoomc/file_directory_functions.py
@@ -131,7 +131,7 @@ def delete_o5m_pbf_files_in_folder(folder):
                 pass
 
 
-def delete_all_files_in_folder(folder):
+def delete_everything_in_folder(folder):
     """
     delete all files ald directories of given folder
     """
@@ -139,7 +139,14 @@ def delete_all_files_in_folder(folder):
 
     for file in files_and_folders:
         try:
-            os.remove(os.path.join(folder, file))
+            file_or_dir = os.path.join(folder, file)
+            # file or dir?
+            if os.path.isfile(file_or_dir):
+                # delete file
+                os.remove(file_or_dir)
+            else:
+                # delete directory if exists. copytree fails if dir exists already
+                shutil.rmtree(file_or_dir)
         except OSError:
             pass
 

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -13,12 +13,12 @@ import sys
 import pkg_resources
 
 # import custom python packages
-from wahoomc.file_directory_functions import write_json_file_generic, \
+from wahoomc.file_directory_functions import delete_all_files_in_folder, write_json_file_generic, \
     read_json_file_generic, copy_or_move_files_and_folder
 from wahoomc.constants_functions import get_tooling_win_path, get_absolute_dir_user_or_repo
 from wahoomc.downloader import get_latest_pypi_version
 
-from wahoomc.constants import GEOFABRIK_PATH, USER_WAHOO_MC
+from wahoomc.constants import GEOFABRIK_PATH, USER_TOOLING_WIN_DIR, USER_WAHOO_MC
 from wahoomc.constants import USER_DL_DIR
 from wahoomc.constants import USER_MAPS_DIR
 from wahoomc.constants import USER_OUTPUT_DIR
@@ -46,6 +46,19 @@ def adjustments_due_to_breaking_changes():
     handle breaking changes
     """
     version_last_run = read_version_last_run() # pylint: disable=unused-variable
+
+    # Osmosis in v.0.49.2 seams not to be working on WINDOWS since now
+    # - due to the path into it was downloaded, 'tooling_win/Osmosis/osmosis-0.49.2'
+    #                                   and not 'tooling_win/Osmosis'
+    # - due to behaviour of reading/using plugins in v0.49.2 that seams not to be compatible
+    #   of using any plugins and in particular the mapwriter plugin
+    # due to that all Windows tooling files deleted here.
+    if (version_last_run is None or \
+            pkg_resources.parse_version(VERSION) <= pkg_resources.parse_version('4.2.1')) and \
+            platform.system() == "Windows":
+        log.info(
+            'Last run was with version %s, deleting Windows Tooling files of %s directory due to possible bad files.', version_last_run, USER_TOOLING_WIN_DIR)
+        delete_all_files_in_folder(USER_TOOLING_WIN_DIR)
 
 
 def check_installation_of_required_programs():

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -13,7 +13,7 @@ import sys
 import pkg_resources
 
 # import custom python packages
-from wahoomc.file_directory_functions import delete_all_files_in_folder, write_json_file_generic, \
+from wahoomc.file_directory_functions import delete_everything_in_folder, write_json_file_generic, \
     read_json_file_generic, copy_or_move_files_and_folder
 from wahoomc.constants_functions import get_tooling_win_path, get_absolute_dir_user_or_repo
 from wahoomc.downloader import get_latest_pypi_version
@@ -58,7 +58,7 @@ def adjustments_due_to_breaking_changes():
             platform.system() == "Windows":
         log.info(
             'Last run was with version %s, deleting Windows Tooling files of %s directory due to possible bad files.', version_last_run, USER_TOOLING_WIN_DIR)
-        delete_all_files_in_folder(USER_TOOLING_WIN_DIR)
+        delete_everything_in_folder(USER_TOOLING_WIN_DIR)
 
 
 def check_installation_of_required_programs():

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -47,12 +47,10 @@ def adjustments_due_to_breaking_changes():
     """
     version_last_run = read_version_last_run() # pylint: disable=unused-variable
 
-    # Osmosis in v.0.49.2 seams not to be working on WINDOWS since now
+    # Osmosis in v.0.49.2 seams not to be working on WINDOWS since the upgrade to v0.49.2
     # - due to the path into it was downloaded, 'tooling_win/Osmosis/osmosis-0.49.2'
     #                                   and not 'tooling_win/Osmosis'
-    # - due to behaviour of reading/using plugins in v0.49.2 that seams not to be compatible
-    #   of using any plugins and in particular the mapwriter plugin
-    # due to that all Windows tooling files deleted here.
+    # - to cleanup, tooling_win/ dir files and folders are deleted here.
     if (version_last_run is None or \
             pkg_resources.parse_version(VERSION) <= pkg_resources.parse_version('4.2.1')) and \
             platform.system() == "Windows":


### PR DESCRIPTION
## This PR…

- unzips the downloaded Osmosis tooling into `Osmosis` dir instead of `Osmosis/osmosis-0.49.2`
- deletes `tooling_win` directory before
- closes partly #258

## Considerations and implementations

The change of having the subdir in the downloaded .zip file came with Osmosis v0.49.0 or 0.49.2

## How to test

1. Checkout branch and use as always

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [x] Tested with Windows
