### PR TITLE
[FIX] Windows: adjust location of mapwriter plugin

### DIFF
--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -138,8 +138,12 @@ def download_tooling():
             download_file(get_tooling_win_path('osmfilter.exe', in_user_dir=True),
                           'http://m.m.i24.cc/osmfilter.exe')
 
-        mapwriter_plugin_path = os.path.join(USER_TOOLING_WIN_DIR,
-                                             'Osmosis', 'lib', 'default', map_writer_filename)
+        # it seams, that as of Osmosis version 0.49.0 or at least in 0.49.2
+        # the old mapwriter plugin location does not work anymore.
+        # until v0.48.3, the location c:\Users\<username>\wahooMapsCreatorData\Osmosis\lib\default worked
+        # since v0.49.0, the location c:\Users\<username>\AppData\Roaming\Openstreetmap\Osmosis\Plugins\ works
+        mapwriter_plugin_path = os.path.join(
+            str(USER_DIR), 'AppData', 'Roaming', 'Openstreetmap', 'Osmosis', 'Plugins', map_writer_filename)
 
     # Non-Windows
     else:


### PR DESCRIPTION
## This PR…

- adjust where the _mapwriter plugin_ is downloaded into, it seams that the possible directories for plugins changed from Osmosis v0.48.3 to 0.49.0/0.49.2
- closes partly #258

## Considerations and implementations

The old mapwriter plugin location does not work anymore.
- until v0.48.3, the location c:\Users\<username>\wahooMapsCreatorData\Osmosis\lib\default worked
- since v0.49.0, the location c:\Users\<username>\AppData\Roaming\Openstreetmap\Osmosis\Plugins\ works

see also
- https://wiki.openstreetmap.org/wiki/Osmosis/Detailed_Usage_0.48#Plugin_Tasks
- https://www.rennrad-news.de/forum/threads/aktuelles-kartenmaterial-f%C3%BCr-wahoo-elemnt-bolt-roam-elemnt-selbst-generieren.175315/page-48#post-6327012

## How to test

1. Checkout this branch and use as always

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [ ] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
