### PR TITLE
[FEAT] Unify method for generating filepath to check map existance and print out the filepath

### DIFF
--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -331,10 +331,11 @@ class Downloader:
 
         for country in self.border_countries:
             # check for already existing .osm.pbf file
-            map_file_path = glob.glob(
-                build_osm_pbf_filepath(country))
+            expected_map_location = build_osm_pbf_filepath(country)
             log.debug(
-                ' Checking for map at filepath: %s',map_file_path[0])
+                ' Checking for map at filepath: %s',expected_map_location)
+            map_file_path = glob.glob(expected_map_location)
+
             if len(map_file_path) != 1:
                 map_file_path = glob.glob(
                     f'{USER_MAPS_DIR}/**/{country}-latest.osm.pbf')

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -332,7 +332,9 @@ class Downloader:
         for country in self.border_countries:
             # check for already existing .osm.pbf file
             map_file_path = glob.glob(
-                f'{USER_MAPS_DIR}/{country}-latest.osm.pbf')
+                build_osm_pbf_filepath(country))
+            log.debug(
+                ' Checking for map at filepath: %s',map_file_path[0])
             if len(map_file_path) != 1:
                 map_file_path = glob.glob(
                     f'{USER_MAPS_DIR}/**/{country}-latest.osm.pbf')


### PR DESCRIPTION
## This PR…

- Resolves an issue where a recent map data file would be downloaded again if the country name includes a slash.

## Considerations and implementations

Used the existing function `build_osm_pbf_filepath` to create the file path to check against instead of the existing method that resulted in checking in a subfolder when a slash was included.

## How to test

1. Run with a -co value that includes a slash like us/delaware
2. After download rerun with the same value and the file won't be downloaded again

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
