### PR TITLE
[FIX] Osmosis fix too many --m flags

### DIFF
--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -493,13 +493,13 @@ class OsmMaps:
                     cmd.append('--merge')
 
                     loop += 1
-            
+
             loop = 0
             for land in land_files:
                 cmd.extend(
                     ['--rx', 'file='+land, '--s'])
                 if loop > 0:
-                       cmd.append('--m')
+                    cmd.append('--m')
                 loop += 1
             if contour:
                 for elevation in elevation_files:

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -496,12 +496,12 @@ class OsmMaps:
 
             for land in land_files:
                 cmd.extend(
-                    ['--rx', 'file='+land, '--s', '--m'])
+                    ['--rx', 'file='+land, '--s'])
 
             if contour:
                 for elevation in elevation_files:
                     cmd.extend(
-                        ['--rx', 'file='+elevation, '--s', '--m'])
+                        ['--rx', 'file='+elevation, '--s'])
 
             cmd.extend(
                 ['--rx', 'file='+os.path.join(out_tile_dir, 'sea.osm'), '--s', '--m'])

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -495,12 +495,15 @@ class OsmMaps:
                     loop += 1
 
             loop = 0
+            # loop through all land* osm files, merge only if more than one file is involved.
             for land in land_files:
                 cmd.extend(
                     ['--rx', 'file='+land, '--s'])
                 if loop > 0:
                     cmd.append('--m')
+
                 loop += 1
+
             if contour:
                 for elevation in elevation_files:
                     cmd.extend(

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -493,15 +493,18 @@ class OsmMaps:
                     cmd.append('--merge')
 
                     loop += 1
-
+            
+            loop = 0
             for land in land_files:
                 cmd.extend(
                     ['--rx', 'file='+land, '--s'])
-
+                if loop > 0:
+                       cmd.append('--m')
+                loop += 1
             if contour:
                 for elevation in elevation_files:
                     cmd.extend(
-                        ['--rx', 'file='+elevation, '--s'])
+                        ['--rx', 'file='+elevation, '--s', '--m'])
 
             cmd.extend(
                 ['--rx', 'file='+os.path.join(out_tile_dir, 'sea.osm'), '--s', '--m'])


### PR DESCRIPTION
## This PR…

- Solves an issue where Osmosis fails due to a merge command after only one input.

## Considerations and implementations

Uses tracking of count of land tile files to exclude the --m flag after the first file.

## How to test

1. ...
2. ...

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
