### PR TITLE
[FEAT] Minimalistic raw maps: Download regions instead of countries

### DIFF
--- a/tests/test_geofabrik.py
+++ b/tests/test_geofabrik.py
@@ -53,12 +53,12 @@ class TestGeofabrik(unittest.TestCase):
         Test the retrieval of tiles via geofabrik URL against hardcoded data
         """
         item_0 = {'x': 137, 'y': 100, 'left': 12.65625, 'top': 36.59788913307021,
-                  'right': 14.0625, 'bottom': 35.4606699514953, 'countries': ['italy', 'malta'],
-                  'urls': ['https://download.geofabrik.de/europe/italy-latest.osm.pbf',
+                  'right': 14.0625, 'bottom': 35.4606699514953, 'countries': ['isole', 'malta'],
+                  'urls': ['https://download.geofabrik.de/europe/italy/isole-latest.osm.pbf',
                            'https://download.geofabrik.de/europe/malta-latest.osm.pbf']}
         item_1 = {'x': 138, 'y': 100, 'left': 14.0625, 'top': 36.59788913307021,
-                  'right': 15.46875, 'bottom': 35.4606699514953, 'countries': ['italy', 'malta'],
-                  'urls': ['https://download.geofabrik.de/europe/italy-latest.osm.pbf',
+                  'right': 15.46875, 'bottom': 35.4606699514953, 'countries': ['isole', 'malta'],
+                  'urls': ['https://download.geofabrik.de/europe/italy/isole-latest.osm.pbf',
                            'https://download.geofabrik.de/europe/malta-latest.osm.pbf']}
 
         geofabrik_tiles = calc_tiles_via_geofabrik_json('malta')
@@ -71,7 +71,7 @@ class TestGeofabrik(unittest.TestCase):
         Test the retrieval of tiles via geofabrik URL against hardcoded data
         """
         item_0 = [{'x': 138, 'y': 100, 'left': 14.0625, 'top': 36.59788913307021, 'right': 15.46875, 'bottom': 35.4606699514953, 'countries': [
-            'italy', 'malta'], 'urls': ['https://download.geofabrik.de/europe/italy-latest.osm.pbf', 'https://download.geofabrik.de/europe/malta-latest.osm.pbf']}]
+            'isole', 'malta'], 'urls': ['https://download.geofabrik.de/europe/italy/isole-latest.osm.pbf', 'https://download.geofabrik.de/europe/malta-latest.osm.pbf']}]
 
         geofabrik_tiles = calc_tiles_via_geofabrik_json_xy('138/100')
 
@@ -89,11 +89,15 @@ class TestGeofabrik(unittest.TestCase):
             "right": 8.4375,
             "bottom": 47.98992166741417,
             "countries": [
-                "france",
-                "germany"
+                "alsace",
+                "freiburg-regbez",
+                "karlsruhe-regbez",
+                "lorraine"
             ],
-            'urls': ['https://download.geofabrik.de/europe/france-latest.osm.pbf',
-                     'https://download.geofabrik.de/europe/germany-latest.osm.pbf']
+            'urls': ['https://download.geofabrik.de/europe/france/alsace-latest.osm.pbf',
+                      'https://download.geofabrik.de/europe/germany/baden-wuerttemberg/freiburg-regbez-latest.osm.pbf',
+                      'https://download.geofabrik.de/europe/germany/baden-wuerttemberg/karlsruhe-regbez-latest.osm.pbf',
+                      'https://download.geofabrik.de/europe/france/lorraine-latest.osm.pbf']
         }]
 
         geofabrik_tiles = calc_tiles_via_geofabrik_json_xy('133/88')
@@ -111,8 +115,8 @@ class TestGeofabrik(unittest.TestCase):
         bbox_tiles_exp = [{'x': 137, 'y': 100, 'tile_left': 12.65625, 'tile_top': 36.59788913307021, 'tile_right': 14.0625, 'tile_bottom': 35.4606699514953}, {
             'x': 138, 'y': 100, 'tile_left': 14.0625, 'tile_top': 36.59788913307021, 'tile_right': 15.46875, 'tile_bottom': 35.4606699514953}]
 
-        tiles_exp = [{'x': 137, 'y': 100, 'left': 12.65625, 'top': 36.59788913307021, 'right': 14.0625, 'bottom': 35.4606699514953, 'countries': ['italy', 'malta'], 'urls': ['https://download.geofabrik.de/europe/italy-latest.osm.pbf', 'https://download.geofabrik.de/europe/malta-latest.osm.pbf']},
-                     {'x': 138, 'y': 100, 'left': 14.0625, 'top': 36.59788913307021, 'right': 15.46875, 'bottom': 35.4606699514953, 'countries': ['italy', 'malta'], 'urls': ['https://download.geofabrik.de/europe/italy-latest.osm.pbf', 'https://download.geofabrik.de/europe/malta-latest.osm.pbf']}]
+        tiles_exp = [{'x': 137, 'y': 100, 'left': 12.65625, 'top': 36.59788913307021, 'right': 14.0625, 'bottom': 35.4606699514953, 'countries': ['isole', 'malta'], 'urls': ['https://download.geofabrik.de/europe/italy/isole-latest.osm.pbf', 'https://download.geofabrik.de/europe/malta-latest.osm.pbf']},
+                     {'x': 138, 'y': 100, 'left': 14.0625, 'top': 36.59788913307021, 'right': 15.46875, 'bottom': 35.4606699514953, 'countries': ['isole', 'malta'], 'urls': ['https://download.geofabrik.de/europe/italy/isole-latest.osm.pbf', 'https://download.geofabrik.de/europe/malta-latest.osm.pbf']}]
 
         wanted_region_exp = 'MULTIPOLYGON (((14 35.7517, 14 36.26791, 14.07957 36.33296, 14.39231 36.29082, 14.8561 35.98808, 14.84002 35.7246, 14.50306 35.51985, 14 35.7517)))'
 

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -30,19 +30,40 @@ class TestOsmMapsCalculation(unittest.TestCase):
 
         # malta
         self.process_and_check_border_countries(
-            'malta', True, {'italy': {}, 'malta': {}}, 'country')
+            'malta', True, {'isole': {}, 'malta': {}}, 'country')
 
         # germany
-        expected_result = {'czech-republic': {}, 'germany': {}, 'austria': {}, 'liechtenstein': {},
-                           'switzerland': {}, 'italy': {}, 'netherlands': {}, 'belgium': {},
-                           'luxembourg': {}, 'france': {}, 'poland': {}, 'denmark': {}, 'sweden': {}}
+        expected_result = {'friesland': {}, 'groningen': {}, 'niedersachsen': {}, 'drenthe': {}, 'flevoland': {},
+                            'gelderland': {}, 'overijssel': {}, 'duesseldorf-regbez': {}, 'limburg': {},
+                            'muenster-regbez': {}, 'noord-brabant': {}, 'utrecht': {}, 'belgium': {},
+                            'koeln-regbez': {}, 'luxembourg': {}, 'rheinland-pfalz': {}, 'alsace': {},
+                            'lorraine': {}, 'saarland': {}, 'denmark': {}, 'schleswig-holstein': {},
+                            'hamburg': {}, 'arnsberg-regbez': {}, 'detmold-regbez': {}, 'hessen': {},
+                            'karlsruhe-regbez': {}, 'freiburg-regbez': {}, 'franche-comte': {}, 'switzerland': {},
+                            'bremen': {}, 'unterfranken': {}, 'stuttgart-regbez': {}, 'tuebingen-regbez': {},
+                            'austria': {}, 'liechtenstein': {}, 'schwaben': {}, 'mecklenburg-vorpommern': {},
+                            'brandenburg': {}, 'sachsen-anhalt': {}, 'thueringen': {}, 'oberfranken': {},
+                            'mittelfranken': {}, 'oberbayern': {}, 'oberpfalz': {}, 'sachsen': {},
+                            'czech-republic': {}, 'niederbayern': {}, 'nord-est': {}, 'sweden': {},
+                            'zachodniopomorskie': {}, 'berlin': {}, 'lubuskie': {}, 'dolnoslaskie': {}}
         self.process_and_check_border_countries(
             'germany', True, expected_result, 'country')
 
         # germany,malta
-        expected_result = {'czech-republic': {}, 'germany': {}, 'austria': {}, 'liechtenstein': {},
-                           'switzerland': {}, 'italy': {}, 'netherlands': {}, 'belgium': {},
-                           'luxembourg': {}, 'france': {}, 'poland': {}, 'denmark': {}, 'sweden': {}, 'malta': {}}
+        expected_result = {'friesland': {}, 'groningen': {}, 'niedersachsen': {}, 'drenthe': {}, 'flevoland': {},
+                            'gelderland': {}, 'overijssel': {}, 'duesseldorf-regbez': {}, 'limburg': {},
+                            'muenster-regbez': {}, 'noord-brabant': {}, 'utrecht': {}, 'belgium': {},
+                            'koeln-regbez': {}, 'luxembourg': {}, 'rheinland-pfalz': {}, 'alsace': {},
+                            'lorraine': {}, 'saarland': {}, 'denmark': {}, 'schleswig-holstein': {},
+                            'hamburg': {}, 'arnsberg-regbez': {}, 'detmold-regbez': {}, 'hessen': {},
+                            'karlsruhe-regbez': {}, 'freiburg-regbez': {}, 'franche-comte': {}, 'switzerland': {},
+                            'bremen': {}, 'unterfranken': {}, 'stuttgart-regbez': {}, 'tuebingen-regbez': {},
+                            'austria': {}, 'liechtenstein': {}, 'schwaben': {}, 'mecklenburg-vorpommern': {},
+                            'brandenburg': {}, 'sachsen-anhalt': {}, 'thueringen': {}, 'oberfranken': {},
+                            'mittelfranken': {}, 'oberbayern': {}, 'oberpfalz': {}, 'sachsen': {},
+                            'czech-republic': {}, 'niederbayern': {}, 'nord-est': {}, 'sweden': {},
+                            'zachodniopomorskie': {}, 'berlin': {}, 'lubuskie': {}, 'dolnoslaskie': {},
+                            'isole' : {}, 'malta' : {} }
         self.process_and_check_border_countries(
             'germany,malta', True, expected_result, 'country')
 
@@ -53,7 +74,7 @@ class TestOsmMapsCalculation(unittest.TestCase):
         """
 
         # one tile - france and germany
-        expected_result = {'france': {}, 'germany': {}}
+        expected_result = {'alsace': {}, 'freiburg-regbez': {}, 'karlsruhe-regbez': {}, 'lorraine': {}}
         self.process_and_check_border_countries(
             "133/88", True, expected_result, 'xy_coordinate')
 
@@ -64,7 +85,8 @@ class TestOsmMapsCalculation(unittest.TestCase):
         """
 
         # two tiles - germany
-        expected_result = {'germany': {}}
+        expected_result = {'freiburg-regbez': {}, 'hessen': {}, 'karlsruhe-regbez': {}, 'rheinland-pfalz': {},
+                           'stuttgart-regbez': {}, 'tuebingen-regbez': {}, 'unterfranken': {} }
         self.process_and_check_border_countries(
             "134/87,134/88", True, expected_result, 'xy_coordinate')
 
@@ -99,7 +121,7 @@ class TestOsmMapsCalculation(unittest.TestCase):
         """
 
         # one tile - france and germany
-        expected_result = {'france': {}, 'germany': {}}
+        expected_result = {'alsace': {}, 'freiburg-regbez': {}, 'karlsruhe-regbez': {}, 'lorraine': {}}
         self.process_and_check_border_countries(
             "133/88", False, expected_result, 'xy_coordinate')
 
@@ -110,7 +132,8 @@ class TestOsmMapsCalculation(unittest.TestCase):
         """
 
         # two tiles - germany
-        expected_result = {'germany': {}}
+        expected_result = {'freiburg-regbez': {}, 'hessen': {}, 'karlsruhe-regbez': {}, 'rheinland-pfalz': {},
+                           'stuttgart-regbez': {}, 'tuebingen-regbez': {}, 'unterfranken': {} }
         self.process_and_check_border_countries(
             "134/87,134/88", False, expected_result, 'xy_coordinate')
 

--- a/wahoomc/constants.py
+++ b/wahoomc/constants.py
@@ -29,8 +29,10 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 VERSION = '4.3.0'
 
 
-block_download = ['africa', 'alps', 'asia', 'australia-oceania', 'britain-and-ireland', 'canada', 'dach', 'europe', 'great-britain' , 'norcal' ,'north-america',
-                  'russia','socal', 'south-africa-and-lesotho', 'south-america', 'us', 'us-midwest', 'us-northeast', 'us-pacific', 'us-south', 'us-west']
+block_download = ['africa', 'alps', 'asia', 'australia-oceania', 'britain-and-ireland',
+                    'canada', 'dach', 'europe', 'great-britain' , 'norcal' ,'north-america',
+                    'russia','socal', 'south-africa-and-lesotho', 'south-america', 'us',
+                    'us-midwest', 'us-northeast', 'us-pacific', 'us-south', 'us-west']
 
 # Special_regions like (former) colonies where the map of the wanted region is not present in the map of the parent country.
 # example Guadeloupe, it's Geofabrik parent country is France but Guadeloupe is not located within the region covered by the map of France.

--- a/wahoomc/constants.py
+++ b/wahoomc/constants.py
@@ -29,8 +29,8 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 VERSION = '4.3.0'
 
 
-block_download = ['dach', 'alps', 'britain-and-ireland', 'south-africa-and-lesotho',
-                  'us-midwest', 'us-northeast', 'us-pacific', 'us-south', 'us-west']
+block_download = ['africa', 'alps', 'asia', 'australia-oceania', 'britain-and-ireland', 'canada', 'dach', 'europe', 'great-britain' , 'norcal' ,'north-america',
+                  'russia','socal', 'south-africa-and-lesotho', 'south-america', 'us', 'us-midwest', 'us-northeast', 'us-pacific', 'us-south', 'us-west']
 
 # Special_regions like (former) colonies where the map of the wanted region is not present in the map of the parent country.
 # example Guadeloupe, it's Geofabrik parent country is France but Guadeloupe is not located within the region covered by the map of France.

--- a/wahoomc/geofabrik.py
+++ b/wahoomc/geofabrik.py
@@ -174,7 +174,7 @@ class CountryGeofabrik(InformalGeofabrikInterface):
                 # currently processing country/region is NOT the desired country/region but might be
                 # in the tile (neighbouring country)
                 if regionname != wanted_map:
-                    # check if we are processing a country or a sub-region. For countries only process other countries. also block special geofabrik sub regions
+                    # Check if the map being processed intersects with the wanted area while checking if it is actually needed.
                     # processing a country and no special sub-region
                     if parent in geofabrik_regions and regionname not in block_download and regionname not in geofabrik_regions:
                         # Check if rshape is a part of the tile

--- a/wahoomc/geofabrik.py
+++ b/wahoomc/geofabrik.py
@@ -108,8 +108,7 @@ class CountryGeofabrik(InformalGeofabrikInterface):
         # get all infos of these bounding box tiles
         tiles_of_input = self.find_needed_countries(
             bbox_tiles, wanted_map, wanted_region)
-        #print (f'Country= {tiles_of_input}')
-        #sys.exit()
+
         return tiles_of_input
 
     def find_needed_countries(self, bbox_tiles, wanted_map, wanted_region_polygon) -> list:
@@ -273,8 +272,7 @@ class XYGeofabrik(InformalGeofabrikInterface):
         # get all infos of these bounding box tiles
         tiles_of_input = self.find_needed_countries(
             bbox_tiles, wanted_map, wanted_region)
-         #print (f'Country= {tiles_of_input}')
-        #sys.exit()
+
         if len(tiles_of_input[0]['countries']) == 0:
             raise XYCombinationHasNoCountries(
                 f'{wanted_map["x"]}/{wanted_map["y"]}')

--- a/wahoomc/geofabrik.py
+++ b/wahoomc/geofabrik.py
@@ -108,7 +108,8 @@ class CountryGeofabrik(InformalGeofabrikInterface):
         # get all infos of these bounding box tiles
         tiles_of_input = self.find_needed_countries(
             bbox_tiles, wanted_map, wanted_region)
-
+        #print (f'Country= {tiles_of_input}')
+        #sys.exit()
         return tiles_of_input
 
     def find_needed_countries(self, bbox_tiles, wanted_map, wanted_region_polygon) -> list:
@@ -163,42 +164,9 @@ class CountryGeofabrik(InformalGeofabrikInterface):
                 if regionname == wanted_map:
                     # Check if it is part of the tile we are processing
                     if rshape.intersects(poly):  # if so
-                        # catch special_regions like (former) colonies where the map of the region is not fysically in the map of the parent country.
-                        # example Guadeloupe, it's parent country is France but Guadeloupe is not located within the region covered by the map of France
-                        if wanted_map not in special_regions:
-                            # If we are proseccing a sub-region add the parent of this sub-region
-                            # to the must download list.
-                            # This to prevent downloading several small regions AND it's containing region
-                            # we are processing a sub-regiongo find the parent region:
-                            if parent not in geofabrik_regions and regionname not in geofabrik_regions:
-                                # we are processing a sub-regiongo find the parent region
-                                x_value = 0
-                                # handle sub-sub-regions like unterfranken->bayern->germany
-                                while parent not in geofabrik_regions:
-                                    parent, child = self.o_geofabrik_json.get_geofabrik_parent_country(
-                                        parent)
-                                    if parent in geofabrik_regions:
-                                        parent = child
-                                        break
-                                    if x_value > 10:  # prevent endless loop
-                                        log.error(
-                                            'Can not find parent map of region: %s', regionname)
-                                        sys.exit()
-                                    x_value += 1
-                                if parent not in must_download_maps:
-                                    must_download_maps.append(parent)
-                                    must_download_urls.append(
-                                        self.o_geofabrik_json.get_geofabrik_url(parent))
-                                    # parent_added = 1
-                            else:
-                                if regionname not in must_download_maps:
-                                    must_download_maps.append(regionname)
-                                    must_download_urls.append(rurl)
-                        else:
-                            # wanted_map is a special region like Guadeloupe, France
-                            if regionname not in must_download_maps:
-                                must_download_maps.append(regionname)
-                                must_download_urls.append(rurl)
+                        if regionname not in must_download_maps and regionname not in geofabrik_regions:
+                            must_download_maps.append(regionname)
+                            must_download_urls.append(rurl)
                         # if there is an intersect, force the tile to be put in the output
                         force_added = 1
                     else:  # currently processing tile does not contain, a part of, the desired region
@@ -207,22 +175,9 @@ class CountryGeofabrik(InformalGeofabrikInterface):
                 # currently processing country/region is NOT the desired country/region but might be
                 # in the tile (neighbouring country)
                 if regionname != wanted_map:
-                    # check if we are processing a country or a sub-region.
-                    # For countries only process other countries. also block special geofabrik sub regions
-                    if parent in geofabrik_regions and regionname not in block_download:
-                        # processing a country and no special sub-region
-                        # check if rshape is subset of desired region. If so discard it
-                        if wanted_region_polygon.contains(rshape):
-                            # print (f'\t{regionname} is a subset of {wanted_map}, discard it')
-                            continue
-                        # check if rshape is a superset of desired region. if so discard it
-                        if rshape.contains(wanted_region_polygon):
-                            # print (f'\t{regionname} is a superset of {wanted_map}, discard it')
-                            # if regionname not in must_download_maps:
-                            #    must_download_maps.append (regionname)
-                            #    must_download_urls.append (rurl)
-                            #    parent_added = 1
-                            continue
+                    # check if we are processing a country or a sub-region. For countries only process other countries. also block special geofabrik sub regions
+                    # processing a country and no special sub-region
+                    if parent in geofabrik_regions and regionname not in block_download and regionname not in geofabrik_regions:
                         # Check if rshape is a part of the tile
                         if rshape.intersects(poly):
                             # print(f'\tintersecting tile: {regionname} tile={tile}')
@@ -318,7 +273,8 @@ class XYGeofabrik(InformalGeofabrikInterface):
         # get all infos of these bounding box tiles
         tiles_of_input = self.find_needed_countries(
             bbox_tiles, wanted_map, wanted_region)
-
+         #print (f'Country= {tiles_of_input}')
+        #sys.exit()
         if len(tiles_of_input[0]['countries']) == 0:
             raise XYCombinationHasNoCountries(
                 f'{wanted_map["x"]}/{wanted_map["y"]}')
@@ -366,16 +322,7 @@ class XYGeofabrik(InformalGeofabrikInterface):
                 rurl = value['pbf_url']
                 rshape = shape(value['geometry'])
 
-                if parent in geofabrik_regions and regionname not in block_download:
-                    # processing a country and no special sub-region
-                    # check if rshape is subset of desired region. If so discard it
-                    if wanted_region_polygon.contains(rshape):
-                        # print (f'\t{regionname} is a subset of {wanted_map}, discard it')
-                        continue
-                    # check if rshape is a superset of desired region. if so discard it
-                    if rshape.contains(wanted_region_polygon):
-                        # print (f'\t{regionname} is a superset of {wanted_map}, discard it')
-                        continue
+                if parent in geofabrik_regions and regionname not in block_download and regionname not in geofabrik_regions:
                     # Check if rshape is a part of the tile / XY
                     if rshape.intersects(poly):
                         # print(f'\tintersecting tile: {regionname} tile={tile}')

--- a/wahoomc/geofabrik_json.py
+++ b/wahoomc/geofabrik_json.py
@@ -73,10 +73,10 @@ class GeofabrikJson:
                     'pbf_url': pbf_url}
                 geofabrik_regions.append(id_no)
 
-        
+
         geofabrik_regions = list(dict.fromkeys(geofabrik_regions))
         try:
-            geofabrik_regions.remove('us/california')        
+            geofabrik_regions.remove('us/california')
         except ValueError:
             pass
         geofabrik_regions.sort()

--- a/wahoomc/geofabrik_json.py
+++ b/wahoomc/geofabrik_json.py
@@ -44,7 +44,7 @@ class GeofabrikJson:
         raw_json = []
         geofabrik_overview = {}
         geofabrik_region_overview = {}
-        geofabrik_regions = []
+        geofabrik_regions = set()
 
         with open(GEOFABRIK_PATH, encoding='utf8') as file_handle:
             raw_json = geojson.load(file_handle)
@@ -64,22 +64,19 @@ class GeofabrikJson:
                     'pbf_url': pbf_url,
                     'geometry': feature.geometry}
                 # Add the parent region of every map/region to the list of regions
-                geofabrik_regions.append(parent)
+                geofabrik_regions.add(parent)
             except KeyError:
                 geofabrik_overview[id_no] = {
                     'pbf_url': pbf_url,
                     'geometry': feature.geometry}
                 geofabrik_region_overview[id_no] = {
                     'pbf_url': pbf_url}
-                geofabrik_regions.append(id_no)
+                geofabrik_regions.add(id_no)
 
-
-        geofabrik_regions = list(dict.fromkeys(geofabrik_regions))
-        try:
+        # Remove 'us/california' if it exists, as it is not needed in the regions list
+        if 'us/california' in geofabrik_regions:
             geofabrik_regions.remove('us/california')
-        except ValueError:
-            pass
-        geofabrik_regions.sort()
+        geofabrik_regions = sorted(geofabrik_regions)
 
         return raw_json, geofabrik_overview, geofabrik_region_overview, geofabrik_regions
 

--- a/wahoomc/geofabrik_json.py
+++ b/wahoomc/geofabrik_json.py
@@ -63,6 +63,8 @@ class GeofabrikJson:
                     'parent': parent,
                     'pbf_url': pbf_url,
                     'geometry': feature.geometry}
+                # Add the parent region of every map/region to the list of regions
+                geofabrik_regions.append(parent)
             except KeyError:
                 geofabrik_overview[id_no] = {
                     'pbf_url': pbf_url,
@@ -70,6 +72,14 @@ class GeofabrikJson:
                 geofabrik_region_overview[id_no] = {
                     'pbf_url': pbf_url}
                 geofabrik_regions.append(id_no)
+
+        
+        geofabrik_regions = list(dict.fromkeys(geofabrik_regions))
+        try:
+            geofabrik_regions.remove('us/california')        
+        except ValueError:
+            pass
+        geofabrik_regions.sort()
 
         return raw_json, geofabrik_overview, geofabrik_region_overview, geofabrik_regions
 

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -339,9 +339,9 @@ class ComboboxesEntryField(tk.Frame):  # pylint: disable=too-many-instance-attri
 
         # Labels
         self.lab_top = tk.Label(
-            self, text="Select continent and country to create a map")
-        self.lab_continent = tk.Label(self, text="Select continent:")
-        self.lab_country = tk.Label(self, text='Select country:')
+            self, text="Select continent/country and country/region to create a map")
+        self.lab_continent = tk.Label(self, text="Select continent/country:")
+        self.lab_country = tk.Label(self, text='Select country/region:')
 
         # Comboboxes
         self.cb_continent = ttk.Combobox(

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -582,7 +582,7 @@ class OsmMaps:
 
             cmd.append(
                 f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')
-            cmd.append('zoom-interval-conf=12,0,17')
+            cmd.append('zoom-interval-conf=10,0,17')
             cmd.append(f'threads={threads}')
             # add path to tag-wahoo xml file
             try:

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -582,7 +582,7 @@ class OsmMaps:
 
             cmd.append(
                 f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')
-            cmd.append('zoom-interval-conf=10,0,17')
+            cmd.append('zoom-interval-conf=12,0,17')
             cmd.append(f'threads={threads}')
             # add path to tag-wahoo xml file
             try:


### PR DESCRIPTION
## This PR…

- Changes the map selection for downloading and processing from using larger region maps i.e. not downloading the US when only New York is needed to smaller region maps i.e. just download New York.
- closes #260

## Considerations and implementations

Minimalistic map selection uses smaller maps when available resulting in potentially smaller downloads and faster processing (it is faster to split tiles from smaller files) See Issue https://github.com/treee111/wahooMapsCreator/issues/260

Nothing to add except a possibly desired side effect is that in the GUI you can now select regions of a country to create.
Instead of selecting continent Europe and country United-kingdom to create a map of lets say London. You can now select country England and region  Greater-London. I call it a plus others might disagree

## How to test

1. Try python -m wahoomc cli -xy 75/96 from issue https://github.com/treee111/wahooMapsCreator/issues/260 and see that the regions processed has changed to us_connecticut,us_new-jersey,us_new-york from us,us_connecticut,us_new-jersey,us_new-york
2. ...

I can't try the final creation of the maps because I can't get gdal to work. So it still needs some testing.

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [ ] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [x] Tested with Windows
