### PR TITLE
[BUGFIX] Get download URL for US regions with slash (us/new-york etc.)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -318,6 +318,18 @@
                 "-con"
                 // "-srtm1"
             ]
+        },
+        {
+            "name": "xy: 75/96 - US splitted download #260",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "wahoomc",
+            "console": "integratedTerminal",
+            "args": [
+                "cli",
+                "-xy",
+                "75/96"
+            ]
         }
     ]
 }

--- a/tests/test_geofabrik.py
+++ b/tests/test_geofabrik.py
@@ -230,6 +230,19 @@ class TestGeofabrik(unittest.TestCase):
     #     with self.assertRaises(TileNotFoundError):
     #         o_geofabrik.get_tiles_of_wanted_map()
 
+    def test_get_geofabrik_url_country_with_slash(self):
+        """
+        check the generation of URL's if the country is not identical with the spelling in the geofabrik area
+        i.e. geofabrik has a slash in US-regions: us/new-york
+        but we have replaced / with _ in the beginning of the whole program
+        """
+
+        o_geofabrik_json = GeofabrikJson()
+
+        self.assertEqual(o_geofabrik_json.get_geofabrik_url('us_connecticut'), o_geofabrik_json.get_geofabrik_url('us/connecticut'))
+        self.assertEqual(o_geofabrik_json.get_geofabrik_url('us_new-jersey'), o_geofabrik_json.get_geofabrik_url('us/new-jersey'))
+        self.assertEqual(o_geofabrik_json.get_geofabrik_url('us_new-york'), o_geofabrik_json.get_geofabrik_url('us/new-york'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -78,14 +78,14 @@ def download_file(target_filepath, url, target_dir=""):
         log.info('+ Downloaded: %s, %s', target_filepath, timings.stop_and_return())
 
 
-def build_osm_pbf_filepath(country_translated):
+def build_osm_pbf_filepath(country):
     """
     build download filepath to countries' OSM file
     replace / to have no problem with directories
     """
-    # build path to downloaded file with translated geofabrik country
+    # build path to downloaded file with geofabrik country
     map_file_path = os.path.join(
-        USER_MAPS_DIR, f'{country_translated.replace("/", "_")}' + '-latest.osm.pbf')
+        USER_MAPS_DIR, f'{country.replace("/", "_")}' + '-latest.osm.pbf')
 
     # return download filepath
     return map_file_path
@@ -366,7 +366,7 @@ class Downloader:
         for country, item in self.border_countries.items():
             try:
                 if item['download'] is True:
-                    # build path to downloaded file with translated geofabrik country
+                    # build path to downloaded file with geofabrik country
                     map_file_path = build_osm_pbf_filepath(country)
                     # fetch the geofabrik download url to countries' OSM file
                     url = self.o_geofabrik_json.get_geofabrik_url(country)

--- a/wahoomc/geofabrik_json.py
+++ b/wahoomc/geofabrik_json.py
@@ -89,13 +89,15 @@ class GeofabrikJson:
     def get_geofabrik_url(self, id_no):
         """
         Get the map download url from a country/region with the already loaded json data
+        if no URL found, try with / instead of _
         """
         try:
             entry = self.geofabrik_overview[id_no]
-            if 'pbf_url' in entry:
-                return entry['pbf_url']
         except KeyError:
-            pass
+            id_with_slash = id_no.replace('_', '/')
+            entry = self.geofabrik_overview[id_with_slash]
+        if 'pbf_url' in entry:
+            return entry['pbf_url']
 
         return None
 


### PR DESCRIPTION
## This PR…

- enhances searching for download URL for geofabrik countries & regions to check secondly country with `_` replaced by `/` in addition to the first requesting with the country spelling we have already

## Considerations and implementations

- in the beginning of wahooMapsCreator, we replace `/` with `_` to have no problem with directories being interrupted with slash.
- thus, a URL for raw map download can not be found when searching with `us_new-york` in the geofabrik data because it is noted as `us/new-york` there

## How to test

1. process for a country/region with `/`, i.e. `us/new-york`, `us/connecticut`
  - `python -m wahoomc cli -co us/connecticut`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
