### PR TITLE
[FEAT] Change zoom-interval-conf from 10,0,17 to 12,0,17 for smaller sub-files in map files

### DIFF
--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -582,7 +582,7 @@ class OsmMaps:
 
             cmd.append(
                 f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')
-            cmd.append('zoom-interval-conf=10,0,17')
+            cmd.append('zoom-interval-conf=12,0,17')
             cmd.append(f'threads={threads}')
             # add path to tag-wahoo xml file
             try:


### PR DESCRIPTION
## This PR…

- changes the used zoom-interval-conf when creating maps to avoid memory issues on older devices (for example part of Paris)
- might help for #272 and #269

## Considerations and implementations

And changed to zoom-interval-conf from 10,0,17 to 12,0,17. This creates smaller sub-files in the resulting maps. This in turn makes sure that for instance Paris can be rendered on the Bolt 1&2 and the roam 1&2. 
Also might help issue https://github.com/treee111/wahooMapsCreator/issues/272 


## How to test

1. already approved in telegram group

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
