### PR TITLE
[BUGFIX] The tooling_win dir for Osmosis was not created during the first run resulting in a runtime error on windows

### DIFF
--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -39,6 +39,7 @@ def initialize_work_directories():
     os.makedirs(USER_MAPS_DIR, exist_ok=True)
     os.makedirs(USER_OUTPUT_DIR, exist_ok=True)
     os.makedirs(USER_CONFIG_DIR, exist_ok=True)
+    os.makedirs(USER_TOOLING_WIN_DIR, exist_ok=True)
 
 
 def adjustments_due_to_breaking_changes():


### PR DESCRIPTION
…resulting in a runtime error on windows

## This PR…

- Creates the tooling_win (for Osmosis) on the initial run. Without it a runtime error is generated on windows

## Considerations and implementations


## How to test

1. ...
2. ...

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [ ] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
