### PR TITLE
[FEAT] Add GUI & CLI switch for mapwriter hdd mode

### DIFF
--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -172,6 +172,18 @@ class TestGeneratedFiles(unittest.TestCase):
         self.compare_dir_sub_test_resource_and_output('138', 'malta')
         self.compare_dir_sub_test_resource_and_output('137', 'malta')
 
+    def test_calc_output_malta_and_compare_hdd_mode(self):
+        """
+        Test output of countries without border countries and WITH mapwriter HDD mode
+        - of malta
+        """
+        # run tool for country in mapwriter hd mode
+        self.run_wahoomapscreator_cli('malta', hdd_mode=True)
+
+        # compare generated given merged.osm.pbf-file with reference-file
+        self.compare_dir_sub_test_resource_and_output('138', 'malta')
+        self.compare_dir_sub_test_resource_and_output('137', 'malta')
+
     def test_calc_output_liechtenstein_and_compare(self):
         """
         Test output of countries without border countries
@@ -183,14 +195,30 @@ class TestGeneratedFiles(unittest.TestCase):
         # compare generated given merged.osm.pbf-file with reference-file
         self.compare_dir_sub_test_resource_and_output('134', 'liechtenstein')
 
-    def run_wahoomapscreator_cli(self, country):
+    def test_calc_output_liechtenstein_and_compare_hdd_mode(self):
+        """
+        Test output of countries without border countries and WITH mapwriter HDD mode
+        - of liechtenstein
+        """
+        # run tool for country in mapwriter hd mode
+        self.run_wahoomapscreator_cli('liechtenstein', hdd_mode=True)
+
+        # compare generated given merged.osm.pbf-file with reference-file
+        self.compare_dir_sub_test_resource_and_output('134', 'liechtenstein')
+
+    def run_wahoomapscreator_cli(self, country, hdd_mode=False):
         """
         runs wahooMapsCreator for given country and static osm.pbf file via CLI
         - without border countries
         """
-        # run processing of input-country via CLI
-        result = os.system(
-            f'python -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc')
+        if not hdd_mode:
+            # run processing of input-country via CLI in standard mode
+            result = os.system(
+                f'python -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc')
+        else:
+            # run processing of input-country via CLI in mapwriter hdd mode
+            result = os.system(
+                f'python -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc -hd')
 
         # check if run was successful
         self.assertEqual(result, 0)

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -86,6 +86,8 @@ def process_call_of_the_tool():
                               help="zip the country (and country-maps) folder")
     options_args.add_argument('-v', '--verbose', action='store_true',
                               help="output debug logger messages")
+    options_args.add_argument('-hd', '--mwhddmode', action='store_true',
+                              help="use mapwriter hdd mode")
 
     args = parser_top.parse_args()
 
@@ -117,6 +119,7 @@ def process_call_of_the_tool():
     o_input_data.zip_folder = args.zip
 
     o_input_data.verbose = args.verbose
+    o_input_data.hdd_mode = args.mwhddmode
 
     return o_input_data
 
@@ -194,6 +197,7 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
         self.tag_wahoo_xml = "tag-wahoo-poi.xml"
         self.zip_folder = False
         self.save_cruiser = False
+        self.hdd_mode = False
 
         self.verbose = False
 
@@ -311,6 +315,7 @@ class GuiInput(tk.Tk):
         self.o_input_data.save_cruiser = tab2.first.checkb_save_cruiser_val.get()
         self.o_input_data.zip_folder = tab2.first.checkb_zip_folder_val.get()
         self.o_input_data.verbose = tab2.first.checkb_verbose_val.get()
+        self.o_input_data.hdd_mode = tab2.first.checkb_mapwriter_ram_hdd_val.get()
 
         # get text without \n in the end
         self.o_input_data.tag_wahoo_xml = tab2.second.input_tag_wahoo_xml.get()
@@ -467,3 +472,5 @@ class CheckbuttonsTab2(tk.Frame):
                                                      "Zip folder with generated files", 3)
         self.checkb_verbose_val = create_checkbox(self, oInputData.verbose,
                                                   "output debug logger messages", 4)
+        self.checkb_mapwriter_ram_hdd_val = create_checkbox(self, oInputData.verbose,
+                                                  "Use mapwriter HDD mode", 5)

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -86,7 +86,7 @@ def process_call_of_the_tool():
                               help="zip the country (and country-maps) folder")
     options_args.add_argument('-v', '--verbose', action='store_true',
                               help="output debug logger messages")
-    options_args.add_argument('-hd', '--mwhddmode', action='store_true',
+    options_args.add_argument('-hdd', '--hdd_mode', action='store_true',
                               help="use mapwriter hdd mode")
 
     args = parser_top.parse_args()
@@ -119,7 +119,7 @@ def process_call_of_the_tool():
     o_input_data.zip_folder = args.zip
 
     o_input_data.verbose = args.verbose
-    o_input_data.hdd_mode = args.mwhddmode
+    o_input_data.hdd_mode = args.hdd_mode
 
     return o_input_data
 

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -96,7 +96,8 @@ def run(run_level):
 
         # Creating .map files
         o_osm_maps.create_map_files(o_input_data.save_cruiser,
-                                    o_input_data.tag_wahoo_xml)
+                                    o_input_data.tag_wahoo_xml,
+                                    o_input_data.hdd_mode)
 
         # Zip .map.lzma files
         o_osm_maps.make_and_zip_files('.map.lzma', o_input_data.zip_folder)

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -545,7 +545,7 @@ class OsmMaps:
 
         log.debug('+ Sorting land* osm files: OK')
 
-    def create_map_files(self, save_cruiser, tag_wahoo_xml):
+    def create_map_files(self, save_cruiser, tag_wahoo_xml, hdd_mode):
         """
         Creating .map files
         """
@@ -584,6 +584,8 @@ class OsmMaps:
                 f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')
             cmd.append('zoom-interval-conf=12,0,17')
             cmd.append(f'threads={threads}')
+            if hdd_mode:
+                cmd.append('type=hd')
             # add path to tag-wahoo xml file
             try:
                 cmd.append(


### PR DESCRIPTION
## This PR…

- Adds GUI & CLI switch for mapwriter hdd mode
- This should solve issue #264
- This PR superseeds #210


## Considerations and implementations

Added a switch in the advance GUI settings and the CLI to enable the mapsforge mapwriter hdd mode. If you run out of memory during map creation you can try this option. As indicated it tries to use the hdd  as memory instead of using ram. The obvious downside to this is it's slower. In my test with Malta using ram mode took 91 seconds in hdd mode it took 158 seconds

## How to test

1. `python -m wahoomc cli -co malta -fp` for standard mode
```
INFO:--------------------------------------------------------------------------------
INFO:# Creating .map files for tiles
INFO:+ (tile 1 of 2) Coordinates: 137,100
INFO:+ (tile 2 of 2) Coordinates: 138,100
INFO:+ Creating .map files for tiles: OK, took 5.886 s
INFO:--------------------------------------------------------------------------------
```
3. `python -m wahoomc cli -co malta -fp -hdd` for hdd mode
```
INFO:--------------------------------------------------------------------------------
INFO:# Creating .map files for tiles
INFO:+ (tile 1 of 2) Coordinates: 137,100
INFO:+ (tile 2 of 2) Coordinates: 138,100
INFO:+ Creating .map files for tiles: OK, took 22.185 s
INFO:--------------------------------------------------------------------------------
```

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
