### PR TITLE
[BUGFIX] trigger event to set value-list of countries at the end of GUI initialization

### DIFF
--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -378,6 +378,9 @@ class ComboboxesEntryField(tk.Frame):  # pylint: disable=too-many-instance-attri
             column=0, row=3, sticky=tk.E, padx=5, pady=2)
         self.en_max_days_old.grid(column=1, row=3, sticky=tk.W, padx=10)
 
+        # trigger event to set value-list of countries at the end of GUI initialization
+        self.cb_continent.event_generate("<<ComboboxSelected>>")
+
     def callback_continent(self, event):  # pylint: disable=unused-argument
         """
         set value-list of countries after changing continent


### PR DESCRIPTION
## This PR…

- triggers event to set value-list of countries at the end of GUI initialization
- closes #282 

## How to test

1. run wahoomc in GUI mode and check for filled list of countries in initial load / for africa
  - `python -m wahoomc gui`

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [x] Tested with Windows
