### PR TITLE
Enable GUI on Windows WSL

### DIFF
--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -6,7 +6,6 @@ functions and object for processing input via CLI and GUI
 # import official python packages
 import argparse
 import sys
-from platform import uname
 
 # for gui
 import tkinter as tk

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -94,10 +94,6 @@ def process_call_of_the_tool():
     # process depending on GUI or CLI processing.
     # returns the input parameters in both cases
     if args.subparser_name == 'gui':
-        # Prevents the initialisation of the graphical GUI on WSL.
-        if 'microsoft' in uname().release:
-            sys.exit("GUI can not be startet because no graphical interface is available. Start with 'python -m wahoo_mc cli -h' or 'python -m wahoo_mc -h' to see command line options.")
-
         o_input_data = GuiInput().start_gui()
         return o_input_data
 


### PR DESCRIPTION
WSL has GUI support for a few years now so no need to block it anymore.

![image](https://github.com/user-attachments/assets/ee10cfac-29e7-46f1-a6fa-8744e1f578c1)

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [ ] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows
