### PR TITLE
Assorted improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pylint==2.15.*
+          pip install pylint==3.3.*
           pip install mock
           pip install requests==2.28.*
       - name: Analysing the code with pylint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pylint==3.3.*
-          pip install mock
           pip install requests==2.28.*
       - name: Analysing the code with pylint
         run: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -17,6 +17,3 @@ disable=line-too-long, duplicate-code
 ; [MASTER]
 ; init-hook='import sys; sys.path.append("/path/to/root")'
 ; init-hook="from pylint.config import find_pylintrc; import os, sys; sys.path.append(os.path.dirname(find_pylintrc()))"
-
-[MASTER]
-init-hook="from pylint.config import find_pylintrc; import os, sys; sys.path.append(os.path.dirname(find_pylintrc()))"

--- a/conda_env/gdal-dev.yml
+++ b/conda_env/gdal-dev.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10
   - gdal=3.6.*
   - requests=2.28.*
-  - pylint=2.15.*
+  - pylint=3.3.*
   - geojson=2.5.*
   - shapely=1.8.*
   - osmium-tool=1.16.*

--- a/conda_env/gdal-dev.yml
+++ b/conda_env/gdal-dev.yml
@@ -13,7 +13,6 @@ dependencies:
   - lxml=4.9.*
   - matplotlib=3.4.3
   - autopep8=2.0.*
-  - mock
   - twine
   - pip
   - vulture

--- a/tests/resources/tags-to-keep.json
+++ b/tests/resources/tags-to-keep.json
@@ -1,0 +1,109 @@
+{
+    "TAGS_TO_KEEP_UNIVERSAL": {
+        "access": "",
+        "area": "yes",
+        "bicycle": "",
+        "bridge": "",
+        "foot": [
+            "ft_yes",
+            "foot_designated"
+        ],
+        "amenity": [
+            "fuel",
+            "cafe",
+            "drinking_water",
+            "shelter"
+        ],
+        "shop": [
+            "bakery",
+            "bicycle"
+        ],
+        "highway": [
+            "abandoned",
+            "bus_guideway",
+            "disused",
+            "bridleway",
+            "byway",
+            "construction",
+            "cycleway",
+            "footway",
+            "living_street",
+            "motorway",
+            "motorway_link",
+            "path",
+            "pedestrian",
+            "primary",
+            "primary_link",
+            "residential",
+            "road",
+            "secondary",
+            "secondary_link",
+            "service",
+            "steps",
+            "tertiary",
+            "tertiary_link",
+            "track",
+            "trunk",
+            "trunk_link",
+            "unclassified"
+        ],
+        "natural": [
+            "coastline",
+            "nosea",
+            "sea",
+            "beach",
+            "land",
+            "scrub",
+            "water",
+            "wetland",
+            "wood"
+        ],
+        "landuse": [
+            "forest",
+            "commercial",
+            "industrial",
+            "residential",
+            "retail"
+        ],
+        "leisure": [
+            "park",
+            "nature_reserve"
+        ],
+        "railway": [
+            "rail",
+            "tram",
+            "station",
+            "stop"
+        ],
+        "surface": "",
+        "tracktype": "",
+        "tunnel": "",
+        "waterway": [
+            "canal",
+            "drain",
+            "river",
+            "riverbank",
+            "stream"
+        ],
+        "wood": "deciduous",
+        "tourism": "alpine_hut"
+    },
+    "NAME_TAGS_TO_KEEP_UNIVERSAL": {
+        "admin_level": "2",
+        "area": "yes",
+        "mountain_pass": "",
+        "natural": "",
+        "place": [
+            "city",
+            "hamlet",
+            "island",
+            "isolated_dwelling",
+            "islet",
+            "locality",
+            "suburb",
+            "town",
+            "village",
+            "country"
+        ]
+    }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 tests for the python file
 """
 import os
+import sys
 import unittest
 
 # import custom python packages
@@ -17,7 +18,7 @@ class TestCli(unittest.TestCase):
         tests, if help of top parser can be called
         """
 
-        result = os.system("python -m wahoomc -h")
+        result = os.system(sys.executable + " -m wahoomc -h")
 
         self.assertEqual(result, 0)
 
@@ -26,7 +27,7 @@ class TestCli(unittest.TestCase):
         tests, if CLI help can be called
         """
 
-        result = os.system("python -m wahoomc cli -h")
+        result = os.system(sys.executable + " -m wahoomc cli -h")
 
         self.assertEqual(result, 0)
 
@@ -35,7 +36,7 @@ class TestCli(unittest.TestCase):
         tests, if GUI help can be called
         """
 
-        result = os.system("python -m wahoomc gui -h")
+        result = os.system(sys.executable + " -m wahoomc gui -h")
 
         self.assertEqual(result, 0)
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -3,24 +3,9 @@ tests for the downloader file
 """
 import os
 import unittest
-import mock
 
 
 from wahoomc.constants_functions import translate_tags_to_keep
-
-
-tags_universal_simple = {"TAGS_TO_KEEP_UNIVERSAL": {
-    'access': '',
-    'area': 'yes'
-}}
-
-tags_universal_adv = {"TAGS_TO_KEEP_UNIVERSAL": {
-    'access': '',
-    'area': 'yes',
-    'bicycle': '',
-    'bridge': '',
-    'foot': ['ft_yes', 'foot_designated']
-}}
 
 
 class TestTranslateTags(unittest.TestCase):
@@ -30,55 +15,6 @@ class TestTranslateTags(unittest.TestCase):
 
     def setUp(self):
         self.tags_to_keep = os.path.join(os.path.dirname(__file__), 'resources', 'tags-to-keep.json')
-
-    @ mock.patch("wahoomc.file_directory_functions.json.load")
-    @ mock.patch("wahoomc.open")
-    def test_translate_tags_to_keep_simple_macos(self, mock_open, mock_json_load):  # pylint: disable=unused-argument
-        """
-        Test translating tags to keep from universal format to macOS
-        """
-        tags = ['access', 'area=yes']
-        mock_json_load.return_value = tags_universal_simple
-
-        transl_tags = translate_tags_to_keep('nonexistant.json')
-        self.assertEqual(tags, transl_tags)
-
-    @ mock.patch("wahoomc.file_directory_functions.json.load")
-    @ mock.patch("wahoomc.open")
-    def test_translate_tags_to_keep_simple_win(self, mock_open, mock_json_load):  # pylint: disable=unused-argument
-        """
-        Test translating tags to keep from universal format to Windows
-        """
-        tags_win = 'access= area=yes'
-        mock_json_load.return_value = tags_universal_simple
-
-        transl_tags = translate_tags_to_keep('nonexistant.json', osmium=False)
-        self.assertEqual(tags_win, transl_tags)
-
-    @ mock.patch("wahoomc.file_directory_functions.json.load")
-    @ mock.patch("wahoomc.open")
-    def test_translate_tags_to_keep_adv_macos(self, mock_open, mock_json_load):  # pylint: disable=unused-argument
-        """
-        Test translating tags to keep from universal format to macOS
-        """
-        tags = ['access', 'area=yes', 'bicycle',
-                'bridge', 'foot=ft_yes, foot_designated']
-        mock_json_load.return_value = tags_universal_adv
-
-        transl_tags = translate_tags_to_keep('nonexistant.json')
-        self.assertEqual(tags, transl_tags)
-
-    @ mock.patch("wahoomc.file_directory_functions.json.load")
-    @ mock.patch("wahoomc.open")
-    def test_translate_tags_to_keep_adv_win(self, mock_open, mock_json_load):  # pylint: disable=unused-argument
-        """
-        Test translating tags to keep from universal format to Windows
-        """
-        tags_win = 'access= area=yes bicycle= bridge= foot=ft_yes =foot_designated'
-        mock_json_load.return_value = tags_universal_adv
-
-        transl_tags = translate_tags_to_keep('nonexistant.json', osmium=False)
-        self.assertEqual(tags_win, transl_tags)
 
     def test_translate_tags_to_keep_full_macos(self):
         """

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,14 +1,11 @@
 """
 tests for the downloader file
 """
-import os
 import unittest
 import mock
 
 
-from wahoomc.constants_functions import translate_tags_to_keep, \
-    get_tag_wahoo_xml_path, TagWahooXmlNotFoundError
-from wahoomc.constants import RESOURCES_DIR
+from wahoomc.constants_functions import translate_tags_to_keep
 
 
 tags_universal_simple = {"TAGS_TO_KEEP_UNIVERSAL": {
@@ -122,29 +119,6 @@ class TestTranslateTags(unittest.TestCase):
 
         transl_tags = translate_tags_to_keep(name_tags=True, osmium=False, use_repo=True)
         self.assertEqual(names_tags_win, transl_tags)
-
-
-class TestTagWahooXML(unittest.TestCase):
-    """
-    tests for tag-wahoo xml file
-    """
-
-    def test_not_existing_tag_wahoo_xml(self):
-        """
-        check if a non-existing tag-wahoo xml file issues an exception
-        """
-        with self.assertRaises(TagWahooXmlNotFoundError):
-            get_tag_wahoo_xml_path("not_existing.xml")
-
-    def test_existing_tag_wahoo_xml(self):
-        """
-        check if the correct path of an existing tag-wahoo xml file is returned
-        """
-
-        expected_path = os.path.join(
-            RESOURCES_DIR, "tag_wahoo_adjusted", "tag-wahoo-poi.xml")
-        self.assertEqual(get_tag_wahoo_xml_path(
-            "tag-wahoo-poi.xml"), expected_path)
 
 
 if __name__ == '__main__':

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,10 +1,12 @@
 """
 tests for the downloader file
 """
+import os
 import unittest
 import mock
 
 
+from wahoomc.constants import RESOURCES_DIR
 from wahoomc.constants_functions import translate_tags_to_keep
 
 
@@ -27,6 +29,9 @@ class TestTranslateTags(unittest.TestCase):
     tests for translating tags-constants between the universal format and OS-specific formats
     """
 
+    def setUp(self):
+        self.tags_to_keep = os.path.join(RESOURCES_DIR, 'tags-to-keep.json')
+
     @ mock.patch("wahoomc.file_directory_functions.json.load")
     @ mock.patch("wahoomc.open")
     def test_translate_tags_to_keep_simple_macos(self, mock_open, mock_json_load):  # pylint: disable=unused-argument
@@ -36,7 +41,7 @@ class TestTranslateTags(unittest.TestCase):
         tags = ['access', 'area=yes']
         mock_json_load.return_value = tags_universal_simple
 
-        transl_tags = translate_tags_to_keep()
+        transl_tags = translate_tags_to_keep('nonexistant.json')
         self.assertEqual(tags, transl_tags)
 
     @ mock.patch("wahoomc.file_directory_functions.json.load")
@@ -48,7 +53,7 @@ class TestTranslateTags(unittest.TestCase):
         tags_win = 'access= area=yes'
         mock_json_load.return_value = tags_universal_simple
 
-        transl_tags = translate_tags_to_keep(osmium=False)
+        transl_tags = translate_tags_to_keep('nonexistant.json', osmium=False)
         self.assertEqual(tags_win, transl_tags)
 
     @ mock.patch("wahoomc.file_directory_functions.json.load")
@@ -61,7 +66,7 @@ class TestTranslateTags(unittest.TestCase):
                 'bridge', 'foot=ft_yes, foot_designated']
         mock_json_load.return_value = tags_universal_adv
 
-        transl_tags = translate_tags_to_keep()
+        transl_tags = translate_tags_to_keep('nonexistant.json')
         self.assertEqual(tags, transl_tags)
 
     @ mock.patch("wahoomc.file_directory_functions.json.load")
@@ -73,7 +78,7 @@ class TestTranslateTags(unittest.TestCase):
         tags_win = 'access= area=yes bicycle= bridge= foot=ft_yes =foot_designated'
         mock_json_load.return_value = tags_universal_adv
 
-        transl_tags = translate_tags_to_keep(osmium=False)
+        transl_tags = translate_tags_to_keep('nonexistant.json', osmium=False)
         self.assertEqual(tags_win, transl_tags)
 
     def test_translate_tags_to_keep_full_macos(self):
@@ -88,7 +93,7 @@ class TestTranslateTags(unittest.TestCase):
                 'leisure=park, nature_reserve', 'railway=rail, tram, station, stop',
                 'surface', 'tracktype', 'tunnel', 'waterway=canal, drain, river, riverbank, stream', 'wood=deciduous', 'tourism=alpine_hut']
 
-        transl_tags = translate_tags_to_keep(use_repo=True)
+        transl_tags = translate_tags_to_keep(self.tags_to_keep)
         self.assertEqual(tags, transl_tags)
 
     def test_translate_tags_to_keep_full_win(self):
@@ -97,7 +102,7 @@ class TestTranslateTags(unittest.TestCase):
         """
         tags_win = 'access= area=yes bicycle= bridge= foot=ft_yes =foot_designated amenity=fuel =cafe =drinking_water =shelter shop=bakery =bicycle highway=abandoned =bus_guideway =disused =bridleway =byway =construction =cycleway =footway =living_street =motorway =motorway_link =path =pedestrian =primary =primary_link =residential =road =secondary =secondary_link =service =steps =tertiary =tertiary_link =track =trunk =trunk_link =unclassified natural=coastline =nosea =sea =beach =land =scrub =water =wetland =wood landuse=forest =commercial =industrial =residential =retail leisure=park =nature_reserve railway=rail =tram =station =stop surface= tracktype= tunnel= waterway=canal =drain =river =riverbank =stream wood=deciduous tourism=alpine_hut'
 
-        transl_tags = translate_tags_to_keep(osmium=False, use_repo=True)
+        transl_tags = translate_tags_to_keep(self.tags_to_keep, osmium=False)
         self.assertEqual(tags_win, transl_tags)
 
     def test_translate_name_tags_to_keep_full_macos(self):
@@ -107,7 +112,7 @@ class TestTranslateTags(unittest.TestCase):
         names_tags = ['admin_level=2', 'area=yes', 'mountain_pass', 'natural',
                       'place=city, hamlet, island, isolated_dwelling, islet, locality, suburb, town, village, country']
 
-        transl_tags = translate_tags_to_keep(name_tags=True, use_repo=True)
+        transl_tags = translate_tags_to_keep(self.tags_to_keep, name_tags=True)
         self.assertEqual(names_tags, transl_tags)
 
     def test_translate_name_tags_to_keep_full_win(self):
@@ -117,7 +122,7 @@ class TestTranslateTags(unittest.TestCase):
 
         names_tags_win = 'admin_level=2 area=yes mountain_pass= natural= place=city =hamlet =island =isolated_dwelling =islet =locality =suburb =town =village =country'
 
-        transl_tags = translate_tags_to_keep(name_tags=True, osmium=False, use_repo=True)
+        transl_tags = translate_tags_to_keep(self.tags_to_keep, name_tags=True, osmium=False)
         self.assertEqual(names_tags_win, transl_tags)
 
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -6,7 +6,6 @@ import unittest
 import mock
 
 
-from wahoomc.constants import RESOURCES_DIR
 from wahoomc.constants_functions import translate_tags_to_keep
 
 
@@ -30,7 +29,7 @@ class TestTranslateTags(unittest.TestCase):
     """
 
     def setUp(self):
-        self.tags_to_keep = os.path.join(RESOURCES_DIR, 'tags-to-keep.json')
+        self.tags_to_keep = os.path.join(os.path.dirname(__file__), 'resources', 'tags-to-keep.json')
 
     @ mock.patch("wahoomc.file_directory_functions.json.load")
     @ mock.patch("wahoomc.open")

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -51,7 +51,7 @@ class TestTranslateTags(unittest.TestCase):
         tags_win = 'access= area=yes'
         mock_json_load.return_value = tags_universal_simple
 
-        transl_tags = translate_tags_to_keep(sys_platform='Windows')
+        transl_tags = translate_tags_to_keep(osmium=False)
         self.assertEqual(tags_win, transl_tags)
 
     @ mock.patch("wahoomc.file_directory_functions.json.load")
@@ -76,7 +76,7 @@ class TestTranslateTags(unittest.TestCase):
         tags_win = 'access= area=yes bicycle= bridge= foot=ft_yes =foot_designated'
         mock_json_load.return_value = tags_universal_adv
 
-        transl_tags = translate_tags_to_keep(sys_platform='Windows')
+        transl_tags = translate_tags_to_keep(osmium=False)
         self.assertEqual(tags_win, transl_tags)
 
     def test_translate_tags_to_keep_full_macos(self):
@@ -100,8 +100,7 @@ class TestTranslateTags(unittest.TestCase):
         """
         tags_win = 'access= area=yes bicycle= bridge= foot=ft_yes =foot_designated amenity=fuel =cafe =drinking_water =shelter shop=bakery =bicycle highway=abandoned =bus_guideway =disused =bridleway =byway =construction =cycleway =footway =living_street =motorway =motorway_link =path =pedestrian =primary =primary_link =residential =road =secondary =secondary_link =service =steps =tertiary =tertiary_link =track =trunk =trunk_link =unclassified natural=coastline =nosea =sea =beach =land =scrub =water =wetland =wood landuse=forest =commercial =industrial =residential =retail leisure=park =nature_reserve railway=rail =tram =station =stop surface= tracktype= tunnel= waterway=canal =drain =river =riverbank =stream wood=deciduous tourism=alpine_hut'
 
-        transl_tags = translate_tags_to_keep(
-            sys_platform='Windows', use_repo=True)
+        transl_tags = translate_tags_to_keep(osmium=False, use_repo=True)
         self.assertEqual(tags_win, transl_tags)
 
     def test_translate_name_tags_to_keep_full_macos(self):
@@ -121,8 +120,7 @@ class TestTranslateTags(unittest.TestCase):
 
         names_tags_win = 'admin_level=2 area=yes mountain_pass= natural= place=city =hamlet =island =isolated_dwelling =islet =locality =suburb =town =village =country'
 
-        transl_tags = translate_tags_to_keep(
-            name_tags=True, sys_platform='Windows', use_repo=True)
+        transl_tags = translate_tags_to_keep(name_tags=True, osmium=False, use_repo=True)
         self.assertEqual(names_tags_win, transl_tags)
 
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -186,7 +186,7 @@ class TestDownloader(unittest.TestCase):
         """
         if platform.system() != "Windows":
             path = os.path.join(str(constants.USER_DIR), '.openstreetmap', 'osmosis',
-                                'plugins', 'mapsforge-map-writer-0.21.0-jar-with-dependencies.jar')
+                                'plugins', 'mapsforge-map-writer-0.25.0-jar-with-dependencies.jar')
 
             if os.path.exists(path):
                 os.remove(path)

--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -7,6 +7,7 @@ import os
 from os import walk
 import platform
 import shutil
+import sys
 import unittest
 import subprocess
 
@@ -214,11 +215,11 @@ class TestGeneratedFiles(unittest.TestCase):
         if not hdd_mode:
             # run processing of input-country via CLI in standard mode
             result = os.system(
-                f'python -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc')
+                f'{sys.executable} -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc')
         else:
             # run processing of input-country via CLI in mapwriter hdd mode
             result = os.system(
-                f'python -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc -hd')
+                f'{sys.executable} -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc -hd')
 
         # check if run was successful
         self.assertEqual(result, 0)

--- a/tests/test_generated_files.py
+++ b/tests/test_generated_files.py
@@ -219,7 +219,7 @@ class TestGeneratedFiles(unittest.TestCase):
         else:
             # run processing of input-country via CLI in mapwriter hdd mode
             result = os.system(
-                f'{sys.executable} -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc -hd')
+                f'{sys.executable} -m wahoomc cli -co {country} -tag tag-wahoo.xml -fp -c -md 9999 -nbc -hdd')
 
         # check if run was successful
         self.assertEqual(result, 0)

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -14,7 +14,15 @@ from wahoomc import file_directory_functions as fd_fct
 from wahoomc import constants
 
 
-class TestOsmMapsCalculation(unittest.TestCase):
+class TestOsmMaps(unittest.TestCase):
+    """
+    base test class
+    """
+
+    def setUp(self):
+        self.tags_to_keep = os.path.join(constants.RESOURCES_DIR, 'tags-to-keep.json')
+
+class TestOsmMapsCalculation(TestOsmMaps):
     """
     tests for the OSM maps file
     """
@@ -164,7 +172,7 @@ class TestOsmMapsCalculation(unittest.TestCase):
         self.assertEqual(result, exp_result)
 
 
-class TestOSMMapsInput(unittest.TestCase):
+class TestOSMMapsInput(TestOsmMaps):
     """
     tests for input of OsmData
     """
@@ -185,7 +193,7 @@ class TestOSMMapsInput(unittest.TestCase):
         """
         o_osm_data = self.get_osm_data_instance('albania,alps,andorra,austria,azores,belarus,belgium,bosnia-herzegovina,britain-and-ireland,bulgaria,croatia,cyprus,czech-republic,dach,denmark,estonia,faroe-islands,finland,france,georgia,germany,great-britain,greece,guernsey-jersey,hungary,iceland,ireland-and-northern-ireland,isle-of-man,italy,kosovo,latvia,liechtenstein,lithuania,luxembourg,macedonia,malta,moldova,monaco,montenegro,netherlands,norway,poland,portugal,romania,serbia,slovakia,slovenia,spain,sweden,switzerland,turkey,ukraine')
 
-        o_osm_maps = OsmMaps(o_osm_data)
+        o_osm_maps = OsmMaps(o_osm_data, self.tags_to_keep)
         folder_name = o_osm_maps.calculate_folder_name('.map.lzma')
         folder_name_maps = o_osm_maps.calculate_folder_name('.map')
 
@@ -216,7 +224,7 @@ class TestOSMMapsInput(unittest.TestCase):
 
         return o_osm_data
 
-class TestConfigFile(unittest.TestCase):
+class TestConfigFile(TestOsmMaps):
     """
     tests for the config .json file in the "wahooMapsCreatorData/_tiles/{country}" directory
     """
@@ -239,7 +247,7 @@ class TestConfigFile(unittest.TestCase):
         # download files marked for download to fill up map_file per country to write to config
         o_downloader.download_files_if_needed()
 
-        o_osm_maps = OsmMaps(o_osm_data)
+        o_osm_maps = OsmMaps(o_osm_data, self.tags_to_keep)
 
         o_osm_maps.write_country_config_file(o_input_data.country)
 

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -148,7 +148,8 @@ class TestOsmMapsCalculation(unittest.TestCase):
         if inp_mode == 'country':
             o_input_data.country = inp_val
             o_osm_data = CountryOsmData(o_input_data)
-        elif inp_mode == 'xy_coordinate':
+        else:
+            self.assertEqual(inp_mode, 'xy_coordinate')
             o_input_data.xy_coordinates = inp_val
             o_osm_data = XYOsmData(o_input_data)
 

--- a/tests/test_osm_maps.py
+++ b/tests/test_osm_maps.py
@@ -21,6 +21,7 @@ class TestOsmMaps(unittest.TestCase):
 
     def setUp(self):
         self.tags_to_keep = os.path.join(constants.RESOURCES_DIR, 'tags-to-keep.json')
+        self.tag_transform = os.path.join(constants.RESOURCES_DIR, 'tunnel-transform.xml')
 
 class TestOsmMapsCalculation(TestOsmMaps):
     """
@@ -193,7 +194,7 @@ class TestOSMMapsInput(TestOsmMaps):
         """
         o_osm_data = self.get_osm_data_instance('albania,alps,andorra,austria,azores,belarus,belgium,bosnia-herzegovina,britain-and-ireland,bulgaria,croatia,cyprus,czech-republic,dach,denmark,estonia,faroe-islands,finland,france,georgia,germany,great-britain,greece,guernsey-jersey,hungary,iceland,ireland-and-northern-ireland,isle-of-man,italy,kosovo,latvia,liechtenstein,lithuania,luxembourg,macedonia,malta,moldova,monaco,montenegro,netherlands,norway,poland,portugal,romania,serbia,slovakia,slovenia,spain,sweden,switzerland,turkey,ukraine')
 
-        o_osm_maps = OsmMaps(o_osm_data, self.tags_to_keep)
+        o_osm_maps = OsmMaps(o_osm_data, self.tags_to_keep, self.tag_transform)
         folder_name = o_osm_maps.calculate_folder_name('.map.lzma')
         folder_name_maps = o_osm_maps.calculate_folder_name('.map')
 
@@ -247,7 +248,7 @@ class TestConfigFile(TestOsmMaps):
         # download files marked for download to fill up map_file per country to write to config
         o_downloader.download_files_if_needed()
 
-        o_osm_maps = OsmMaps(o_osm_data, self.tags_to_keep)
+        o_osm_maps = OsmMaps(o_osm_data, self.tags_to_keep, self.tag_transform)
 
         o_osm_maps.write_country_config_file(o_input_data.country)
 

--- a/wahoomc/constants_functions.py
+++ b/wahoomc/constants_functions.py
@@ -22,25 +22,14 @@ class TagsToKeepNotFoundError(Exception):
     """Raised when the specified tags to keep .json file does not exist"""
 
 
-def translate_tags_to_keep(name_tags=False, osmium=True, use_repo=False):
+def translate_tags_to_keep(tags_to_keep, name_tags=False, osmium=True):
     """
     translates the given tags to format of the operating system.
     """
     tags_modif = []
 
-    # read tags-to-keep .json from user-dir in favor of python installation
-    # evaluate path first: user-dir in favor of PyPI installation
-    if not use_repo:
-        for path in get_absolute_dir_user_or_repo('', file='tags-to-keep.json'):
-            if os.path.exists(path):
-                break
-    # force using file from repo - used in unittests for equal output
-    else:
-        path = get_absolute_dir_user_or_repo(
-            '', file='tags-to-keep.json')[1]
-
-    # read the tags from the evaluated path above
-    tags_from_json = read_json_file_generic(path)
+    # read the tags from the passed tags_to_keep path
+    tags_from_json = read_json_file_generic(tags_to_keep)
 
     if not tags_from_json:
         raise TagsToKeepNotFoundError

--- a/wahoomc/constants_functions.py
+++ b/wahoomc/constants_functions.py
@@ -18,10 +18,6 @@ from wahoomc.file_directory_functions import read_json_file_generic
 log = logging.getLogger('main-logger')
 
 
-class TagWahooXmlNotFoundError(Exception):
-    """Raised when the specified tag-wahoo xml file does not exist"""
-
-
 class TagsToKeepNotFoundError(Exception):
     """Raised when the specified tags to keep .json file does not exist"""
 
@@ -103,21 +99,6 @@ def get_tooling_win_path(path_in_tooling_win, in_user_dir=False):
 
     # all other "toolings": concatenate with win tooling dir
     return os.path.join(tooling_dir, path_in_tooling_win)
-
-
-def get_tag_wahoo_xml_path(tag_wahoo_xml):
-    """
-    return path to tag-wahoo xml file if the file exists
-    - from the user directory "USER_WAHOO_MC/_config/tag_wahoo_adjusted/tag_wahoo_xml"
-    - 2ndly from the PyPI installation: "RESOURCES_DIR/tag_wahoo_adjusted/tag_wahoo_xml"
-    """
-
-    for path in get_absolute_dir_user_or_repo("tag_wahoo_adjusted", tag_wahoo_xml):
-        if os.path.exists(path):
-            return path
-
-    raise TagWahooXmlNotFoundError
-
 
 def get_absolute_dir_user_or_repo(folder, file=''):
     """

--- a/wahoomc/constants_functions.py
+++ b/wahoomc/constants_functions.py
@@ -26,16 +26,10 @@ class TagsToKeepNotFoundError(Exception):
     """Raised when the specified tags to keep .json file does not exist"""
 
 
-def translate_tags_to_keep(name_tags=False, sys_platform='', use_repo=False):
+def translate_tags_to_keep(name_tags=False, osmium=True, use_repo=False):
     """
     translates the given tags to format of the operating system.
     """
-
-    if sys_platform == "Windows":
-        separator = ' ='
-    else:
-        separator = ', '
-
     tags_modif = []
 
     # read tags-to-keep .json from user-dir in favor of python installation
@@ -61,21 +55,22 @@ def translate_tags_to_keep(name_tags=False, sys_platform='', use_repo=False):
         universal_tags = tags_from_json['NAME_TAGS_TO_KEEP_UNIVERSAL']
 
     for tag, value in universal_tags.items():
-        to_append = transl_tag_value(sys_platform, separator, tag, value)
+        to_append = transl_tag_value(osmium, tag, value)
 
         tags_modif.append(to_append)
 
-    if sys_platform == "Windows":
+    if not osmium:
         tags_modif = ' '.join(tags_modif)
 
     return tags_modif
 
 
-def transl_tag_value(sys_platform, separator, tag, value):
+def transl_tag_value(osmium, tag, value):
     """
     translates one tag with value(s) to a "common" format
     """
     if isinstance(value, list):
+        separator = ', ' if osmium else ' ='
         for iteration, sing_val in enumerate(value):
             if iteration == 0:
                 to_append = f'{tag}={sing_val}'
@@ -84,10 +79,7 @@ def transl_tag_value(sys_platform, separator, tag, value):
     elif value:
         to_append = f'{tag}={value}'
     else:
-        if sys_platform == "Windows":
-            to_append = f'{tag}='
-        else:
-            to_append = tag
+        to_append = tag if osmium else f'{tag}='
 
     return to_append
 

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -119,8 +119,8 @@ def download_tooling():
 
     check here for new mapwriter plugin version: https://github.com/mapsforge/mapsforge
     """
-    map_writer_filename = 'mapsforge-map-writer-0.21.0-jar-with-dependencies.jar'
-    mapwriter_plugin_url = 'https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.21.0/' + map_writer_filename
+    map_writer_filename = 'mapsforge-map-writer-0.25.0-jar-with-dependencies.jar'
+    mapwriter_plugin_url = 'https://search.maven.org/remotecontent?filepath=org/mapsforge/mapsforge-map-writer/0.25.0/' + map_writer_filename
 
     # Windows
     if platform.system() == "Windows":

--- a/wahoomc/downloader.py
+++ b/wahoomc/downloader.py
@@ -180,7 +180,7 @@ def get_latest_pypi_version():
         response = requests.get(
             'https://pypi.org/pypi/wahoomc/json', timeout=1)
         return response.json()['info']['version']
-    except (requests.ConnectionError, requests.Timeout):
+    except (requests.ConnectionError, requests.Timeout, requests.exceptions.JSONDecodeError):
         return None
 
 

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -201,7 +201,8 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
 
         self.verbose = False
 
-    def is_required_input_given_or_exit(self):
+
+    def is_required_input_given_or_exit(self): # pylint: disable=too-many-branches
         """
         check, if the minimal required arguments is given:
         - country
@@ -212,20 +213,18 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
         if (self.country in ('None', '') and self.xy_coordinates in ('None', '')):
             sys.exit("Nothing to do. Start with -h or --help to see command line options."
                      "Or in the GUI select a country to create maps for.")
-        elif self.country and self.xy_coordinates:
-            sys.exit(
-                "Country and X/Y coordinates are given. Only one of both is allowed!")
-        elif self.country:
+
+        if self.country and self.xy_coordinates:
+            sys.exit("Country and X/Y coordinates are given. Only one of both is allowed!")
+
+        if self.country:
             # countries =
             try:
                 CountryGeofabrik.split_input_to_list(self.country)
             except CountyIsNoGeofabrikCountry as exception:
                 sys.exit(exception)
 
-            # if we made it until here, sys.exit() was not called and therefore all countries OK ;-)
-            return True
-        else:
-            return True
+        return True
 
 
 class GuiInput(tk.Tk):

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -83,6 +83,9 @@ def process_call_of_the_tool():
     # specify the file with tags to keep when filtering
     options_args.add_argument('--tags_to_keep', default=InputData().tags_to_keep,
                               help="file with tags to keep when filtering")
+    # specify the file with tag-transform rules
+    options_args.add_argument('--tag_transform', default=InputData().tag_transform,
+                              help="file with tag-transform rules")
     # specify the file with tags to keep in the output
     options_args.add_argument('-tag', '--tag_wahoo_xml', default=InputData().tag_wahoo_xml,
                               help="file with tags to keep in the output")
@@ -120,6 +123,7 @@ def process_call_of_the_tool():
     o_input_data.force_processing = args.forceprocessing
 
     o_input_data.tags_to_keep = args.tags_to_keep
+    o_input_data.tag_transform = args.tag_transform
     o_input_data.tag_wahoo_xml = args.tag_wahoo_xml
     o_input_data.save_cruiser = args.cruiser
     o_input_data.zip_folder = args.zip
@@ -201,6 +205,7 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
         self.use_srtm1 = False
 
         self.tags_to_keep = "tags-to-keep.json"
+        self.tag_transform = "tunnel-transform.xml"
         self.tag_wahoo_xml = "tag-wahoo-poi.xml"
         self.zip_folder = False
         self.save_cruiser = False
@@ -239,6 +244,15 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
 
         if not os.path.exists(self.tags_to_keep):
             sys.exit(f'The tags-to-keep json file was not found: \"{self.tags_to_keep}\"')
+
+        if not os.path.exists(self.tag_transform):
+            for path in get_absolute_dir_user_or_repo("", self.tag_transform):
+                if os.path.exists(path):
+                    self.tag_transform = path
+                    break
+
+        if not os.path.exists(self.tag_transform):
+            sys.exit(f'The tag-transform xml file was not found: \"{self.tag_transform}\"')
 
         if not os.path.exists(self.tag_wahoo_xml):
             for path in get_absolute_dir_user_or_repo("tag_wahoo_adjusted", self.tag_wahoo_xml):

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -80,6 +80,9 @@ def process_call_of_the_tool():
     # Save uncompressed maps for Cruiser if True
     options_args.add_argument('-c', '--cruiser', action='store_true',
                               help="save uncompressed maps for Cruiser")
+    # specify the file with tags to keep when filtering
+    options_args.add_argument('--tags_to_keep', default=InputData().tags_to_keep,
+                              help="file with tags to keep when filtering")
     # specify the file with tags to keep in the output
     options_args.add_argument('-tag', '--tag_wahoo_xml', default=InputData().tag_wahoo_xml,
                               help="file with tags to keep in the output")
@@ -116,6 +119,7 @@ def process_call_of_the_tool():
     o_input_data.force_download = args.forcedownload
     o_input_data.force_processing = args.forceprocessing
 
+    o_input_data.tags_to_keep = args.tags_to_keep
     o_input_data.tag_wahoo_xml = args.tag_wahoo_xml
     o_input_data.save_cruiser = args.cruiser
     o_input_data.zip_folder = args.zip
@@ -196,6 +200,7 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
         self.contour = False
         self.use_srtm1 = False
 
+        self.tags_to_keep = "tags-to-keep.json"
         self.tag_wahoo_xml = "tag-wahoo-poi.xml"
         self.zip_folder = False
         self.save_cruiser = False
@@ -225,6 +230,15 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
                 CountryGeofabrik.split_input_to_list(self.country)
             except CountyIsNoGeofabrikCountry as exception:
                 sys.exit(exception)
+
+        if not os.path.exists(self.tags_to_keep):
+            for path in get_absolute_dir_user_or_repo("", self.tags_to_keep):
+                if os.path.exists(path):
+                    self.tags_to_keep = path
+                    break
+
+        if not os.path.exists(self.tags_to_keep):
+            sys.exit(f'The tags-to-keep json file was not found: \"{self.tags_to_keep}\"')
 
         if not os.path.exists(self.tag_wahoo_xml):
             for path in get_absolute_dir_user_or_repo("tag_wahoo_adjusted", self.tag_wahoo_xml):

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -5,6 +5,7 @@ functions and object for processing input via CLI and GUI
 
 # import official python packages
 import argparse
+import os
 import sys
 from platform import uname
 
@@ -13,6 +14,7 @@ import tkinter as tk
 from tkinter import ttk
 
 # import custom python packages
+from wahoomc.constants_functions import get_absolute_dir_user_or_repo
 from wahoomc.geofabrik_json import GeofabrikJson
 from wahoomc.geofabrik_json import CountyIsNoGeofabrikCountry
 from wahoomc.geofabrik import CountryGeofabrik
@@ -78,7 +80,7 @@ def process_call_of_the_tool():
     # Save uncompressed maps for Cruiser if True
     options_args.add_argument('-c', '--cruiser', action='store_true',
                               help="save uncompressed maps for Cruiser")
-    # specify the file with tags to keep in the output // file needs to be in wahoo_mc/resources/tag_wahoo_adjusted
+    # specify the file with tags to keep in the output
     options_args.add_argument('-tag', '--tag_wahoo_xml', default=InputData().tag_wahoo_xml,
                               help="file with tags to keep in the output")
     # zip the country (and country-maps) folder
@@ -223,6 +225,15 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
                 CountryGeofabrik.split_input_to_list(self.country)
             except CountyIsNoGeofabrikCountry as exception:
                 sys.exit(exception)
+
+        if not os.path.exists(self.tag_wahoo_xml):
+            for path in get_absolute_dir_user_or_repo("tag_wahoo_adjusted", self.tag_wahoo_xml):
+                if os.path.exists(path):
+                    self.tag_wahoo_xml = path
+                    break
+
+        if not os.path.exists(self.tag_wahoo_xml):
+            sys.exit(f'The tag-wahoo xml file was not found: \"{self.tag_wahoo_xml}\"')
 
         return True
 

--- a/wahoomc/input.py
+++ b/wahoomc/input.py
@@ -201,7 +201,7 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
 
         self.verbose = False
 
-    def is_required_input_given_or_exit(self, issue_message):
+    def is_required_input_given_or_exit(self):
         """
         check, if the minimal required arguments is given:
         - country
@@ -210,11 +210,8 @@ class InputData():  # pylint: disable=too-many-instance-attributes,too-few-publi
         If not, depending on the import parameter, the
         """
         if (self.country in ('None', '') and self.xy_coordinates in ('None', '')):
-            if issue_message:
-                sys.exit("Nothing to do. Start with -h or --help to see command line options."
-                         "Or in the GUI select a country to create maps for.")
-            else:
-                sys.exit()
+            sys.exit("Nothing to do. Start with -h or --help to see command line options."
+                     "Or in the GUI select a country to create maps for.")
         elif self.country and self.xy_coordinates:
             sys.exit(
                 "Country and X/Y coordinates are given. Only one of both is allowed!")
@@ -250,7 +247,7 @@ class GuiInput(tk.Tk):
         # start GUI
         self.mainloop()
 
-        self.o_input_data.is_required_input_given_or_exit(issue_message=True)
+        self.o_input_data.is_required_input_given_or_exit()
         return self.o_input_data
 
     def build_gui(self):

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -62,6 +62,7 @@ def run(run_level):
             check_installation_of_programs_credentials_for_contour_lines()
 
         log.info('# Used configuration')
+        log.info('+ tags-to-keep file: %s', o_input_data.tags_to_keep)
         log.info('+ map-writer tag-conf file: %s', o_input_data.tag_wahoo_xml)
 
         if o_input_data.country:
@@ -77,7 +78,7 @@ def run(run_level):
         # Download files marked for download
         o_downloader.download_files_if_needed()
 
-        o_osm_maps = OsmMaps(o_osm_data)
+        o_osm_maps = OsmMaps(o_osm_data, o_input_data.tags_to_keep)
 
         # Filter tags from country osm.pbf files'
         o_osm_maps.filter_tags_from_country_osm_pbf_files()

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -63,6 +63,7 @@ def run(run_level):
 
         log.info('# Used configuration')
         log.info('+ tags-to-keep file: %s', o_input_data.tags_to_keep)
+        log.info('+ tag-transform file: %s', o_input_data.tag_transform)
         log.info('+ map-writer tag-conf file: %s', o_input_data.tag_wahoo_xml)
 
         if o_input_data.country:
@@ -78,7 +79,7 @@ def run(run_level):
         # Download files marked for download
         o_downloader.download_files_if_needed()
 
-        o_osm_maps = OsmMaps(o_osm_data, o_input_data.tags_to_keep)
+        o_osm_maps = OsmMaps(o_osm_data, o_input_data.tags_to_keep, o_input_data.tag_transform)
 
         # Filter tags from country osm.pbf files'
         o_osm_maps.filter_tags_from_country_osm_pbf_files()

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -61,7 +61,7 @@ def run(run_level):
 
         if o_input_data.country:
             o_osm_data = CountryOsmData(o_input_data)
-        elif o_input_data.xy_coordinates:
+        else:
             o_osm_data = XYOsmData(o_input_data)
 
         timings = Timings()

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -18,6 +18,8 @@ from wahoomc.timings import Timings
 from wahoomc.osm_maps_functions import OsmMaps
 from wahoomc.osm_data import CountryOsmData, XYOsmData
 
+log = logging.getLogger('main-logger')
+
 # logging used in the terminal output:
 # # means top-level command
 # ! means error
@@ -47,7 +49,7 @@ def run(run_level):
         o_input_data = process_call_of_the_tool()
 
     if o_input_data.verbose:
-        logging.getLogger().setLevel(logging.DEBUG)
+        log.setLevel(logging.DEBUG)
 
     if run_level == 'init':
         copy_jsons_from_repo_to_user('tag_wahoo_adjusted')
@@ -58,6 +60,9 @@ def run(run_level):
 
         if o_input_data.contour:
             check_installation_of_programs_credentials_for_contour_lines()
+
+        log.info('# Used configuration')
+        log.info('+ map-writer tag-conf file: %s', o_input_data.tag_wahoo_xml)
 
         if o_input_data.country:
             o_osm_data = CountryOsmData(o_input_data)

--- a/wahoomc/main.py
+++ b/wahoomc/main.py
@@ -54,7 +54,7 @@ def run(run_level):
         copy_jsons_from_repo_to_user('.', 'tags-to-keep.json')
     else:
         # Is there something to do?
-        o_input_data.is_required_input_given_or_exit(issue_message=True)
+        o_input_data.is_required_input_given_or_exit()
 
         if o_input_data.contour:
             check_installation_of_programs_credentials_for_contour_lines()

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -567,6 +567,7 @@ class OsmMaps:
                 f'bbox={tile["bottom"]:.6f},{tile["left"]:.6f},{tile["top"]:.6f},{tile["right"]:.6f}')
             cmd.append('zoom-interval-conf=12,0,17')
             cmd.append(f'threads={threads}')
+            cmd.append('tag-values=true')
             if hdd_mode:
                 cmd.append('type=hd')
             cmd.append(f'tag-conf-file={tag_conf_file}')

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -38,6 +38,7 @@ def run_subprocess_and_log_output(cmd, error_message, cwd=""):
     """
     run given cmd-subprocess and issue error message if wished
     """
+    log.debug('running subprocess: %s', str(cmd))
     if not cwd:
         process = subprocess.run(
             cmd, capture_output=True, text=True, encoding="utf-8", check=False)

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -43,9 +43,7 @@ def run_subprocess_and_log_output(cmd, error_message, cwd=""):
             cmd, capture_output=True, text=True, encoding="utf-8", check=False)
 
     else:
-        process = subprocess.run(  # pylint: disable=consider-using-with
-            cmd, capture_output=True, cwd=cwd, text=True, encoding="utf-8", check=False)
-
+        process = subprocess.run(cmd, capture_output=True, cwd=cwd, text=True, encoding="utf-8", check=False)
 
     if error_message and process.returncode != 0:  # 0 means success
         log.error('subprocess error output:')
@@ -450,7 +448,7 @@ class OsmMaps:
         log.info('# Merge splitted tiles with land, elevation, and sea')
         timings = Timings()
         tile_count = 1
-        for tile in self.o_osm_data.tiles:  # pylint: disable=too-many-nested-blocks
+        for tile in self.o_osm_data.tiles:
             self.log_tile_info(tile["x"], tile["y"], tile_count)
             timings_tile = Timings()
 
@@ -785,7 +783,7 @@ class OsmMaps:
         """
         self.log_tile(tile_x, tile_y, tile_count, True, additional_info)
 
-    def log_tile(self, tile_x, tile_y, tile_count, log_level_debug, additional_info=''):  # pylint: disable=too-many-arguments
+    def log_tile(self, tile_x, tile_y, tile_count, log_level_debug, additional_info=''):  # pylint: disable=too-many-arguments,too-many-positional-arguments
         """
         unified status logging for this class
         """

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -75,8 +75,9 @@ class OsmMaps:
     # Number of workers for the Osmosis read binary fast function
     workers = '1'
 
-    def __init__(self, o_osm_data):
+    def __init__(self, o_osm_data, tags_to_keep):
         self.o_osm_data = o_osm_data
+        self.tags_to_keep = tags_to_keep
         self.osmconvert_path = get_tooling_win_path('osmconvert')
 
         create_empty_directories(
@@ -131,8 +132,8 @@ class OsmMaps:
                         '+ Filtering unwanted map objects out of map of %s', key)
                     cmd = [get_tooling_win_path('osmfilter', in_user_dir=True)]
                     cmd.append(out_file_o5m)
-                    cmd.append('--keep="' + translate_tags_to_keep(osmium=False) + '"')
-                    cmd.append('--keep-tags="all type= layer= ' + translate_tags_to_keep(osmium=False) + '"')
+                    cmd.append('--keep="' + translate_tags_to_keep(self.tags_to_keep, osmium=False) + '"')
+                    cmd.append('--keep-tags="all type= layer= ' + translate_tags_to_keep(self.tags_to_keep, osmium=False) + '"')
                     cmd.append('-o=' + out_file_o5m_filtered_win)
 
                     run_subprocess_and_log_output(
@@ -140,8 +141,8 @@ class OsmMaps:
 
                     cmd = [get_tooling_win_path('osmfilter', in_user_dir=True)]
                     cmd.append(out_file_o5m)
-                    cmd.append('--keep="' + translate_tags_to_keep(name_tags=True, osmium=False) + '"')
-                    cmd.append('--keep-tags="all type= name= layer= ' + translate_tags_to_keep(name_tags=True, osmium=False) + '"')
+                    cmd.append('--keep="' + translate_tags_to_keep(self.tags_to_keep, name_tags=True, osmium=False) + '"')
+                    cmd.append('--keep-tags="all type= name= layer= ' + translate_tags_to_keep(self.tags_to_keep, name_tags=True, osmium=False) + '"')
                     cmd.append('-o=' + out_file_o5m_filtered_names_win)
 
                     run_subprocess_and_log_output(
@@ -168,7 +169,7 @@ class OsmMaps:
                     # https://docs.osmcode.org/osmium/latest/osmium-tags-filter.html
                     cmd = ['osmium', 'tags-filter', '--remove-tags']
                     cmd.append(val['map_file'])
-                    cmd.extend(translate_tags_to_keep())
+                    cmd.extend(translate_tags_to_keep(self.tags_to_keep))
                     cmd.extend(['-o', out_file_pbf_filtered_mac])
                     cmd.append('--overwrite')
 
@@ -177,7 +178,7 @@ class OsmMaps:
 
                     cmd = ['osmium', 'tags-filter', '--remove-tags']
                     cmd.append(val['map_file'])
-                    cmd.extend(translate_tags_to_keep(name_tags=True))
+                    cmd.extend(translate_tags_to_keep(self.tags_to_keep, name_tags=True))
                     cmd.extend(['-o', out_file_pbf_filtered_names_mac])
                     cmd.append('--overwrite')
 
@@ -708,8 +709,8 @@ class OsmMaps:
         configuration = {
             "version_last_run": VERSION,
             "changed_ts_map_last_run": get_timestamp_last_changed(self.o_osm_data.border_countries[country]['map_file']),
-            "tags_last_run": translate_tags_to_keep(),
-            "name_tags_last_run": translate_tags_to_keep(name_tags=True)
+            "tags_last_run": translate_tags_to_keep(self.tags_to_keep),
+            "name_tags_last_run": translate_tags_to_keep(self.tags_to_keep, name_tags=True)
         }
 
         write_json_file_generic(os.path.join(
@@ -724,8 +725,8 @@ class OsmMaps:
         try:
             country_config = read_json_file_country_config(os.path.join(
                 USER_OUTPUT_DIR, country, ".config.json"))
-            if not country_config["tags_last_run"] == translate_tags_to_keep() \
-                    or not country_config["name_tags_last_run"] == translate_tags_to_keep(name_tags=True):
+            if not country_config["tags_last_run"] == translate_tags_to_keep(self.tags_to_keep) \
+                    or not country_config["name_tags_last_run"] == translate_tags_to_keep(self.tags_to_keep, name_tags=True):
                 tags_are_identical = False
         except (FileNotFoundError, KeyError):
             tags_are_identical = False

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -16,8 +16,7 @@ import logging
 
 # import custom python packages
 from wahoomc.file_directory_functions import read_json_file_country_config, create_empty_directories, write_json_file_generic
-from wahoomc.constants_functions import translate_tags_to_keep, \
-    get_tooling_win_path, get_tag_wahoo_xml_path, TagWahooXmlNotFoundError
+from wahoomc.constants_functions import translate_tags_to_keep, get_tooling_win_path
 
 from wahoomc.setup_functions import read_earthexplorer_credentials
 
@@ -528,7 +527,7 @@ class OsmMaps:
 
         log.debug('+ Sorting land* osm files: OK')
 
-    def create_map_files(self, save_cruiser, tag_wahoo_xml, hdd_mode):
+    def create_map_files(self, save_cruiser, tag_conf_file, hdd_mode):
         """
         Creating .map files
         """
@@ -569,14 +568,7 @@ class OsmMaps:
             cmd.append(f'threads={threads}')
             if hdd_mode:
                 cmd.append('type=hd')
-            # add path to tag-wahoo xml file
-            try:
-                cmd.append(
-                    f'tag-conf-file={get_tag_wahoo_xml_path(tag_wahoo_xml)}')
-            except TagWahooXmlNotFoundError:
-                log.error(
-                    'The tag-wahoo xml file was not found: ˚%s˚. Does the file exist and is your input correct?', tag_wahoo_xml)
-                sys.exit()
+            cmd.append(f'tag-conf-file={tag_conf_file}')
 
             run_subprocess_and_log_output(
                 cmd, f'Error in creating map file via Osmosis with tile: {tile["x"]},{tile["y"]}. mapwriter plugin installed?')

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -132,10 +132,8 @@ class OsmMaps:
                         '+ Filtering unwanted map objects out of map of %s', key)
                     cmd = [get_tooling_win_path('osmfilter', in_user_dir=True)]
                     cmd.append(out_file_o5m)
-                    cmd.append(
-                        '--keep="' + translate_tags_to_keep(sys_platform=platform.system()) + '"')
-                    cmd.append('--keep-tags="all type= layer= ' +
-                               translate_tags_to_keep(sys_platform=platform.system()) + '"')
+                    cmd.append('--keep="' + translate_tags_to_keep(osmium=False) + '"')
+                    cmd.append('--keep-tags="all type= layer= ' + translate_tags_to_keep(osmium=False) + '"')
                     cmd.append('-o=' + out_file_o5m_filtered_win)
 
                     run_subprocess_and_log_output(
@@ -143,12 +141,8 @@ class OsmMaps:
 
                     cmd = [get_tooling_win_path('osmfilter', in_user_dir=True)]
                     cmd.append(out_file_o5m)
-                    cmd.append(
-                        '--keep="' + translate_tags_to_keep(
-                            name_tags=True, sys_platform=platform.system()) + '"')
-                    cmd.append('--keep-tags="all type= name= layer= ' +
-                               translate_tags_to_keep(
-                                   name_tags=True, sys_platform=platform.system()) + '"')
+                    cmd.append('--keep="' + translate_tags_to_keep(name_tags=True, osmium=False) + '"')
+                    cmd.append('--keep-tags="all type= name= layer= ' + translate_tags_to_keep(name_tags=True, osmium=False) + '"')
                     cmd.append('-o=' + out_file_o5m_filtered_names_win)
 
                     run_subprocess_and_log_output(
@@ -175,8 +169,7 @@ class OsmMaps:
                     # https://docs.osmcode.org/osmium/latest/osmium-tags-filter.html
                     cmd = ['osmium', 'tags-filter', '--remove-tags']
                     cmd.append(val['map_file'])
-                    cmd.extend(translate_tags_to_keep(
-                        sys_platform=platform.system()))
+                    cmd.extend(translate_tags_to_keep())
                     cmd.extend(['-o', out_file_pbf_filtered_mac])
                     cmd.append('--overwrite')
 
@@ -185,8 +178,7 @@ class OsmMaps:
 
                     cmd = ['osmium', 'tags-filter', '--remove-tags']
                     cmd.append(val['map_file'])
-                    cmd.extend(translate_tags_to_keep(
-                        name_tags=True, sys_platform=platform.system()))
+                    cmd.extend(translate_tags_to_keep(name_tags=True))
                     cmd.extend(['-o', out_file_pbf_filtered_names_mac])
                     cmd.append('--overwrite')
 
@@ -724,8 +716,8 @@ class OsmMaps:
         configuration = {
             "version_last_run": VERSION,
             "changed_ts_map_last_run": get_timestamp_last_changed(self.o_osm_data.border_countries[country]['map_file']),
-            "tags_last_run": translate_tags_to_keep(sys_platform=platform.system()),
-            "name_tags_last_run": translate_tags_to_keep(name_tags=True, sys_platform=platform.system())
+            "tags_last_run": translate_tags_to_keep(),
+            "name_tags_last_run": translate_tags_to_keep(name_tags=True)
         }
 
         write_json_file_generic(os.path.join(
@@ -740,8 +732,8 @@ class OsmMaps:
         try:
             country_config = read_json_file_country_config(os.path.join(
                 USER_OUTPUT_DIR, country, ".config.json"))
-            if not country_config["tags_last_run"] == translate_tags_to_keep(sys_platform=platform.system()) \
-                    or not country_config["name_tags_last_run"] == translate_tags_to_keep(name_tags=True, sys_platform=platform.system()):
+            if not country_config["tags_last_run"] == translate_tags_to_keep() \
+                    or not country_config["name_tags_last_run"] == translate_tags_to_keep(name_tags=True):
                 tags_are_identical = False
         except (FileNotFoundError, KeyError):
             tags_are_identical = False

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -75,9 +75,10 @@ class OsmMaps:
     # Number of workers for the Osmosis read binary fast function
     workers = '1'
 
-    def __init__(self, o_osm_data, tags_to_keep):
+    def __init__(self, o_osm_data, tags_to_keep, tag_transform):
         self.o_osm_data = o_osm_data
         self.tags_to_keep = tags_to_keep
+        self.tag_transform = tag_transform
         self.osmconvert_path = get_tooling_win_path('osmconvert')
 
         create_empty_directories(
@@ -488,8 +489,7 @@ class OsmMaps:
 
             cmd.extend(
                 ['--rx', 'file='+os.path.join(out_tile_dir, 'sea.osm'), '--s', '--m'])
-            cmd.extend(['--tag-transform', 'file=' + os.path.join(RESOURCES_DIR,
-                                                                  'tunnel-transform.xml'), '--wb', out_file_merged, 'omitmetadata=true'])
+            cmd.extend(['--tag-transform', 'file=' + self.tag_transform, '--wb', out_file_merged, 'omitmetadata=true'])
 
             run_subprocess_and_log_output(
                 cmd, f'! Error in Osmosis with tile: {tile["x"]},{tile["y"]}')

--- a/wahoomc/osm_maps_functions.py
+++ b/wahoomc/osm_maps_functions.py
@@ -239,16 +239,8 @@ class OsmMaps:
 
             # create land1.osm
             if not os.path.isfile(out_file_land1+'1.osm') or self.o_osm_data.force_processing is True:
-                # Windows
-                if platform.system() == "Windows":
-                    cmd = ['python', os.path.join(RESOURCES_DIR,
-                                                  'shape2osm.py'), '-l', out_file_land1, land_file]
-
-                # Non-Windows
-                else:
-                    cmd = ['python', os.path.join(RESOURCES_DIR,
-                                                  'shape2osm.py'), '-l', out_file_land1, land_file]
-
+                cmd = [sys.executable, os.path.join(RESOURCES_DIR,
+                                                   'shape2osm.py'), '-l', out_file_land1, land_file]
                 run_subprocess_and_log_output(
                     cmd, f'! Error creating land.osm for tile: {tile["x"]},{tile["y"]}')
             self.log_tile_debug(tile["x"], tile["y"], tile_count, timings_tile.stop_and_return())

--- a/wahoomc/resources/tag_wahoo_adjusted/tag-wahoo-poi.xml
+++ b/wahoomc/resources/tag_wahoo_adjusted/tag-wahoo-poi.xml
@@ -171,11 +171,6 @@
 
   <!-- NOT TO RENDER -->
   <ways>
-    <osm-tag key="id" renderable="false" value="%f" />
-
-    <osm-tag key="ref" renderable="false" value="%s" />
-    <osm-tag key="name" renderable="false" value="%s" />
-
     <osm-tag key="access" value="destination" renderable="false"/>
     <osm-tag key="access" value="private" renderable="false"/>
 

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -45,7 +45,7 @@ def adjustments_due_to_breaking_changes():
     """
     handle breaking changes
     """
-    version_last_run = read_version_last_run() # pylint: disable=unused-variable
+    version_last_run = read_version_last_run()
 
     # Osmosis in v.0.49.2 seams not to be working on WINDOWS since the upgrade to v0.49.2
     # - due to the path into it was downloaded, 'tooling_win/Osmosis/osmosis-0.49.2'


### PR DESCRIPTION
## This PR…

...is just a bunch of smaller things I noticed while starting with this nice tool.
The commits are small and easy to review (I hope).

Some of it is mostly internal stuff, the nice user-facing change is that `-tag_wahoo_xml` now accepts random filenames, and not just relative ones to the internal `resources` directory.
Similar, there's now `--tags_to_keep` and `--tag_transform` with the exact same logic.

As most major themes will touch all three of the mentioned files, it's now possible to have multiple themes, each with their own configuration files, next to each other and build them without messing around in the pip install or user config directories.

## Caveats

I didn't touch the unittests nor the gui.
The former will have to be adapted if these changes are accepted.
The latter should still work, but could be extended to handle the new command line switches.

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
    + Especially the [Pull-Requests](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md#Pull-Requests) section
- [x] Commits (and commit-messages) are understandable
- [x] Tested with macOS / Linux
- [ ] Tested with Windows
