### PR TITLE
[FIX] Replace pkg_resources version parsing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pylint==2.15.*
           pip install mock
+          pip install packaging
           pip install requests==2.28.*
       - name: Analysing the code with pylint
         run: |

--- a/conda_env/gdal-dev.yml
+++ b/conda_env/gdal-dev.yml
@@ -12,6 +12,7 @@ dependencies:
   - bs4=4.11.*
   - lxml=4.9.*
   - matplotlib=3.4.3
+  - packaging
   - autopep8=2.0.*
   - mock
   - twine

--- a/conda_env/gdal-user.yml
+++ b/conda_env/gdal-user.yml
@@ -8,6 +8,7 @@ dependencies:
   - bs4=4.11.*
   - lxml=4.9.*
   - matplotlib=3.4.3
+  - packaging
   - pip
   - pip:
       - wahoomc==4.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifiers =
 [options]
 packages = wahoomc, wahoomc.init
 python_requires = >=3.10
+install_requires =
+    packaging
 
 [options.package_data]
 wahoomc = resources/*.*, resources/*/*.*, resources/*/*/*.*, resources/*/*/*/*.*, tooling_win/*.*, tooling_win/*/*.*, tooling_win/*/*/*.*, tooling_win/*/*/*/*.*

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -4,7 +4,7 @@ tests for setup functions
 import unittest
 import platform
 import os
-import pkg_resources
+from packaging.version import parse as parse_version
 
 # import custom python packages
 from wahoomc.setup_functions import is_program_installed, is_map_writer_plugin_installed, \
@@ -97,7 +97,7 @@ class TestConfigFile(unittest.TestCase):
         """
         tests, if the version of constants.py is equal to the latest available version on PyPI
         """
-        latest_version = pkg_resources.parse_version(
+        latest_version = parse_version(
             get_latest_pypi_version()).public
 
         self.assertEqual(

--- a/wahoomc/setup_functions.py
+++ b/wahoomc/setup_functions.py
@@ -10,7 +10,7 @@ import platform
 import shutil
 from pathlib import Path
 import sys
-import pkg_resources
+from packaging.version import parse as parse_version
 
 # import custom python packages
 from wahoomc.file_directory_functions import delete_everything_in_folder, write_json_file_generic, \
@@ -52,7 +52,7 @@ def adjustments_due_to_breaking_changes():
     #                                   and not 'tooling_win/Osmosis'
     # - to cleanup, tooling_win/ dir files and folders are deleted here.
     if (version_last_run is None or \
-            pkg_resources.parse_version(VERSION) <= pkg_resources.parse_version('4.2.1')) and \
+            parse_version(VERSION) <= parse_version('4.2.1')) and \
             platform.system() == "Windows":
         log.info(
             'Last run was with version %s, deleting Windows Tooling files of %s directory due to possible bad files.', version_last_run, USER_TOOLING_WIN_DIR)
@@ -254,7 +254,7 @@ def check_installed_version_against_latest_pypi():
 
     # compare installed version against latest and issue a info if a new version is available
     if latest_version \
-            and pkg_resources.parse_version(VERSION) < pkg_resources.parse_version(latest_version):
+            and parse_version(VERSION) < parse_version(latest_version):
         log.info('\n\nUpdate available! \
                 \nA new version of wahoomc is available: "%s". You have installed version "%s". \
                 \nUpgrade wahoomc with "pip install wahoomc --upgrade". \


### PR DESCRIPTION
## This PR...

- replaces `pkg_resources.parse_version()` with `packaging.version.parse`
- declares `packaging` for package installs, conda envs, and the pylint workflow

Fixes #295.

## Considerations and implementations

`pkg_resources` is no longer available with recent setuptools releases, so the runtime import in `wahoomc/setup_functions.py` prevents the CLI from starting. `packaging.version.parse` provides the version comparison behavior needed here without depending on `pkg_resources`.

## How to test

Not run locally.

Static validation performed:

- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `rg -n pkg_resources|parse_version|packaging wahoomc tests setup.cfg pyproject.toml conda_env .github`

## Pull Request Checklist

- [x] Reviewed the [Contributing Guidelines](https://github.com/treee111/wahooMapsCreator/blob/develop/docs/CONTRIBUTING.md)
- [x] Commits (and commit-messages) are understandable
- [ ] Tested with macOS / Linux
- [ ] Tested with Windows